### PR TITLE
Updated records on the border of the Netherlands

### DIFF
--- a/data/117/561/054/7/1175610547.geojson
+++ b/data/117/561/054/7/1175610547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000311,
-    "geom:area_square_m":1521567.378764,
+    "geom:area_square_m":2431458.626634,
     "geom:bbox":"5.65220175956,50.7777266131,5.67910817048,50.8177860177",
     "geom:latitude":50.798842,
     "geom:longitude":5.667299,
@@ -74,7 +74,6 @@
         102191581,
         85632997,
         404227353,
-        101810467,
         102049941
     ],
     "wof:breaches":[],
@@ -93,13 +92,13 @@
             "continent_id":102191581,
             "country_id":85632997,
             "county_id":102049941,
-            "locality_id":101810467,
+            "locality_id":1175610547,
             "macroregion_id":404227353,
             "region_id":85681691
         }
     ],
     "wof:id":1175610547,
-    "wof:lastmodified":1534985844,
+    "wof:lastmodified":1559587839,
     "wof:name":"Kanne",
     "wof:parent_id":102049941,
     "wof:placetype":"locality",

--- a/data/124/339/978/7/1243399787.geojson
+++ b/data/124/339/978/7/1243399787.geojson
@@ -28,10 +28,11 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
+        85687033,
         102191581,
         404474645,
         85633337,
-        85687033
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -43,13 +44,14 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474645,
             "locality_id":1243399787,
             "region_id":85687033
         }
     ],
     "wof:id":1243399787,
-    "wof:lastmodified":1536871783,
+    "wof:lastmodified":1559594437,
     "wof:name":"Nurop",
     "wof:parent_id":404474645,
     "wof:placetype":"locality",

--- a/data/124/359/084/3/1243590843.geojson
+++ b/data/124/359/084/3/1243590843.geojson
@@ -28,10 +28,11 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
+        85687035,
         102191581,
         404474459,
         85633337,
-        85687035
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -43,13 +44,14 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474459,
             "locality_id":1243590843,
             "region_id":85687035
         }
     ],
     "wof:id":1243590843,
-    "wof:lastmodified":1537090976,
+    "wof:lastmodified":1559594437,
     "wof:name":"Oosthuisheuvel",
     "wof:parent_id":404474459,
     "wof:placetype":"locality",

--- a/data/125/991/466/7/1259914667.geojson
+++ b/data/125/991/466/7/1259914667.geojson
@@ -30,10 +30,11 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
+        85687033,
         102191581,
         404474531,
         85633337,
-        85687033
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -45,13 +46,14 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474531,
             "locality_id":1259914667,
             "region_id":85687033
         }
     ],
     "wof:id":1259914667,
-    "wof:lastmodified":1536734391,
+    "wof:lastmodified":1559594437,
     "wof:name":"Brandven",
     "wof:parent_id":404474531,
     "wof:placetype":"locality",

--- a/data/126/001/551/7/1260015517.geojson
+++ b/data/126/001/551/7/1260015517.geojson
@@ -28,10 +28,11 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
+        85687037,
         102191581,
         404474629,
         85633337,
-        85687037
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -43,13 +44,14 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474629,
             "locality_id":1260015517,
             "region_id":85687037
         }
     ],
     "wof:id":1260015517,
-    "wof:lastmodified":1537082655,
+    "wof:lastmodified":1559594436,
     "wof:name":"Maagd van Gent",
     "wof:parent_id":404474629,
     "wof:placetype":"locality",

--- a/data/126/001/597/3/1260015973.geojson
+++ b/data/126/001/597/3/1260015973.geojson
@@ -28,10 +28,11 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
+        85687037,
         102191581,
         404474329,
         85633337,
-        85687037
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -43,13 +44,14 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474329,
             "locality_id":1260015973,
             "region_id":85687037
         }
     ],
     "wof:id":1260015973,
-    "wof:lastmodified":1537081973,
+    "wof:lastmodified":1559594436,
     "wof:name":"Holleken",
     "wof:parent_id":404474329,
     "wof:placetype":"locality",

--- a/data/129/332/386/3/1293323863.geojson
+++ b/data/129/332/386/3/1293323863.geojson
@@ -28,10 +28,11 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
+        85687037,
         102191581,
         404474329,
         85633337,
-        85687037
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -43,13 +44,14 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474329,
             "locality_id":1293323863,
             "region_id":85687037
         }
     ],
     "wof:id":1293323863,
-    "wof:lastmodified":1537022041,
+    "wof:lastmodified":1559594435,
     "wof:name":"Rode Sluis",
     "wof:parent_id":404474329,
     "wof:placetype":"locality",

--- a/data/129/342/587/9/1293425879.geojson
+++ b/data/129/342/587/9/1293425879.geojson
@@ -28,10 +28,11 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
+        85687033,
         102191581,
         404474559,
         85633337,
-        85687033
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -43,13 +44,14 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474559,
             "locality_id":1293425879,
             "region_id":85687033
         }
     ],
     "wof:id":1293425879,
-    "wof:lastmodified":1536874889,
+    "wof:lastmodified":1559594436,
     "wof:name":"Vijverbroek",
     "wof:parent_id":404474559,
     "wof:placetype":"locality",

--- a/data/131/014/200/9/1310142009.geojson
+++ b/data/131/014/200/9/1310142009.geojson
@@ -32,10 +32,11 @@
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
+        85687037,
         102191581,
         404474307,
         85633337,
-        85687037
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,13 +48,14 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474307,
             "locality_id":1310142009,
             "region_id":85687037
         }
     ],
     "wof:id":1310142009,
-    "wof:lastmodified":1537587021,
+    "wof:lastmodified":1559594435,
     "wof:name":"Heikant",
     "wof:parent_id":404474307,
     "wof:placetype":"locality",

--- a/data/131/014/217/5/1310142175.geojson
+++ b/data/131/014/217/5/1310142175.geojson
@@ -30,10 +30,11 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
+        85687037,
         102191581,
         404474629,
         85633337,
-        85687037
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -45,13 +46,14 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474629,
             "locality_id":1310142175,
             "region_id":85687037
         }
     ],
     "wof:id":1310142175,
-    "wof:lastmodified":1536944071,
+    "wof:lastmodified":1559594435,
     "wof:name":"Oosthoek",
     "wof:parent_id":404474629,
     "wof:placetype":"locality",

--- a/data/131/062/967/9/1310629679.geojson
+++ b/data/131/062/967/9/1310629679.geojson
@@ -32,10 +32,11 @@
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
+        85687037,
         102191581,
         404474629,
         85633337,
-        85687037
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,13 +48,14 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474629,
             "locality_id":1310629679,
             "region_id":85687037
         }
     ],
     "wof:id":1310629679,
-    "wof:lastmodified":1537587046,
+    "wof:lastmodified":1559594434,
     "wof:name":"Ede",
     "wof:parent_id":404474629,
     "wof:placetype":"locality",

--- a/data/132/676/460/7/1326764607.geojson
+++ b/data/132/676/460/7/1326764607.geojson
@@ -33,10 +33,11 @@
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
+        85687033,
         102191581,
         404474627,
         85633337,
-        85687033
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -48,13 +49,14 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474627,
             "locality_id":1326764607,
             "region_id":85687033
         }
     ],
     "wof:id":1326764607,
-    "wof:lastmodified":1537587043,
+    "wof:lastmodified":1559594437,
     "wof:name":"Elerweert",
     "wof:parent_id":404474627,
     "wof:placetype":"locality",

--- a/data/132/686/064/1/1326860641.geojson
+++ b/data/132/686/064/1/1326860641.geojson
@@ -28,10 +28,11 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
+        85687033,
         102191581,
         404474675,
         85633337,
-        85687033
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -43,13 +44,14 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474675,
             "locality_id":1326860641,
             "region_id":85687033
         }
     ],
     "wof:id":1326860641,
-    "wof:lastmodified":1537007201,
+    "wof:lastmodified":1559594436,
     "wof:name":"Negenoord",
     "wof:parent_id":404474675,
     "wof:placetype":"locality",

--- a/data/857/975/65/85797565.geojson
+++ b/data/857/975/65/85797565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
-    "geom:area_square_m":12632934.258449,
+    "geom:area_square_m":0.0,
     "geom:bbox":"6.058216,50.891282,6.058216,50.891282",
     "geom:latitude":50.891282,
     "geom:longitude":6.058216,
@@ -64,7 +64,8 @@
         102191581,
         404474489,
         85633337,
-        1158817899
+        1158817899,
+        136253051
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,6 +79,7 @@
         {
             "continent_id":102191581,
             "country_id":85633337,
+            "empire_id":136253051,
             "localadmin_id":404474489,
             "locality_id":1158817899,
             "neighbourhood_id":85797565,
@@ -88,7 +90,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1531861890,
+    "wof:lastmodified":1559595824,
     "wof:name":"Geitberg",
     "wof:parent_id":1158817899,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
This PR contains "leftover" records in Belgium that were updated during PIP work in the Netherlands repo. Each of these six records need either:

- Better, more accurate geometries
- an is_current = 0 flag and deprecated date

Then, they need their hierarchies rebuilt.

See: https://github.com/whosonfirst-data/whosonfirst-data-admin-nl/pull/1