### PR TITLE
be placetype local and more

### DIFF
--- a/data/856/329/97/85632997.geojson
+++ b/data/856/329/97/85632997.geojson
@@ -22,6 +22,9 @@
     "itu:country_code":[
         "32"
     ],
+    "label:eng_x_preferred_placetype":[
+        "country"
+    ],
     "label:eng_x_preferred_shortcode":[
         "BE"
     ],
@@ -1412,7 +1415,7 @@
         "naturalearth-display-terrestrial-zoom6",
         "naturalearth"
     ],
-    "wof:geomhash":"46c0a0d08da0a862ea3d1b71de377dbe",
+    "wof:geomhash":"76687c18a825b3ff10851cdd8f80b20b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -1430,7 +1433,7 @@
         "fra",
         "deu"
     ],
-    "wof:lastmodified":1690856406,
+    "wof:lastmodified":1694492228,
     "wof:name":"Belgium",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2154. Sets placetype local, names, populations, and statoids properties for CARTO