### PR TITLE
BE concordances, placetype local, and more

### DIFF
--- a/data/102/049/907/102049907.geojson
+++ b/data/102/049/907/102049907.geojson
@@ -219,12 +219,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"385",
         "eurostat:nuts_2021_id":"BE345",
         "hasc:id":"BE.LX.VT",
         "wd:id":"Q456495"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"813063cbf194176cff9874fc3cd5bb49",
+    "wof:geomhash":"09cd979164f0c22a00bad024a8dafeb6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -235,7 +240,7 @@
         }
     ],
     "wof:id":102049907,
-    "wof:lastmodified":1690856395,
+    "wof:lastmodified":1695886580,
     "wof:name":"Virton",
     "wof:parent_id":85681727,
     "wof:placetype":"county",

--- a/data/102/049/909/102049909.geojson
+++ b/data/102/049/909/102049909.geojson
@@ -300,12 +300,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"381",
         "eurostat:nuts_2021_id":"BE341",
         "hasc:id":"BE.LX.AR",
         "wd:id":"Q675960"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"85fd6d70255cda97f3933f7e16d645b5",
+    "wof:geomhash":"5e6254286b241f7d0a9786f545673c6b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -316,7 +321,7 @@
         }
     ],
     "wof:id":102049909,
-    "wof:lastmodified":1690856394,
+    "wof:lastmodified":1695886580,
     "wof:name":"Arlon",
     "wof:parent_id":85681727,
     "wof:placetype":"county",

--- a/data/102/049/913/102049913.geojson
+++ b/data/102/049/913/102049913.geojson
@@ -161,9 +161,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"384",
         "eurostat:nuts_2021_id":"BE344",
         "hasc:id":"BE.LX.NC"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"ff34756a0de5b02f9b7ca66af4ad80c3",
     "wof:hierarchy":[
@@ -176,7 +181,7 @@
         }
     ],
     "wof:id":102049913,
-    "wof:lastmodified":1684351492,
+    "wof:lastmodified":1695886580,
     "wof:name":"Neufch\u00e2teau",
     "wof:parent_id":85681727,
     "wof:placetype":"county",

--- a/data/102/049/915/102049915.geojson
+++ b/data/102/049/915/102049915.geojson
@@ -224,9 +224,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"382",
         "eurostat:nuts_2021_id":"BE342",
         "hasc:id":"BE.LX.BS"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"9e1bde13a04b4b458aba56abf1b5e97c",
     "wof:hierarchy":[
@@ -239,7 +244,7 @@
         }
     ],
     "wof:id":102049915,
-    "wof:lastmodified":1684351492,
+    "wof:lastmodified":1695886580,
     "wof:name":"Bastogne",
     "wof:parent_id":85681727,
     "wof:placetype":"county",

--- a/data/102/049/917/102049917.geojson
+++ b/data/102/049/917/102049917.geojson
@@ -228,12 +228,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"393",
         "eurostat:nuts_2021_id":"BE353",
         "hasc:id":"BE.NA.PV",
         "wd:id":"Q650239"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"2be0357e0e5bc96c36eb10b499a5f340",
+    "wof:geomhash":"63e0021d45e86a736ac993238c7b019c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -244,7 +249,7 @@
         }
     ],
     "wof:id":102049917,
-    "wof:lastmodified":1690856400,
+    "wof:lastmodified":1695886580,
     "wof:name":"Philippeville",
     "wof:parent_id":85681699,
     "wof:placetype":"county",

--- a/data/102/049/919/102049919.geojson
+++ b/data/102/049/919/102049919.geojson
@@ -255,12 +255,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"391",
         "eurostat:nuts_2021_id":"BE351",
         "hasc:id":"BE.NA.DN",
         "wd:id":"Q108247"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"af6c67fcb5396eeed79ec196519d0cdc",
+    "wof:geomhash":"9655a15d776a514d4537ff6819d55fa5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -271,7 +276,7 @@
         }
     ],
     "wof:id":102049919,
-    "wof:lastmodified":1690856400,
+    "wof:lastmodified":1695886580,
     "wof:name":"Dinant",
     "wof:parent_id":85681699,
     "wof:placetype":"county",

--- a/data/102/049/921/102049921.geojson
+++ b/data/102/049/921/102049921.geojson
@@ -219,12 +219,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"383",
         "eurostat:nuts_2021_id":"BE343",
         "hasc:id":"BE.LX.MR",
         "wd:id":"Q269908"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"15216cf6ceb8e06d503cc1c39b189d83",
+    "wof:geomhash":"fc84018fa1431c85a01634a5d7654da2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -235,7 +240,7 @@
         }
     ],
     "wof:id":102049921,
-    "wof:lastmodified":1690856400,
+    "wof:lastmodified":1695886581,
     "wof:name":"Marche-en-Famenne",
     "wof:parent_id":85681727,
     "wof:placetype":"county",

--- a/data/102/049/923/102049923.geojson
+++ b/data/102/049/923/102049923.geojson
@@ -216,12 +216,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"356",
         "eurostat:nuts_2021_id":"BE32D",
         "hasc:id":"BE.HT.TN",
         "wd:id":"Q669186"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"153d41bf053b8c70639ec94199fa9f18",
+    "wof:geomhash":"04d2a711f2e1307e9bf9005b9e944b3f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -232,7 +237,7 @@
         }
     ],
     "wof:id":102049923,
-    "wof:lastmodified":1690856397,
+    "wof:lastmodified":1695886581,
     "wof:name":"Thuin",
     "wof:parent_id":85681723,
     "wof:placetype":"county",

--- a/data/102/049/925/102049925.geojson
+++ b/data/102/049/925/102049925.geojson
@@ -258,12 +258,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"361",
         "eurostat:nuts_2021_id":"BE331",
         "hasc:id":"BE.LG.HY",
         "wd:id":"Q207095"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"f03164ec25ad784b35fb5f576be421bd",
+    "wof:geomhash":"4d72eeadea95bef88539ea17f751f494",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -274,7 +279,7 @@
         }
     ],
     "wof:id":102049925,
-    "wof:lastmodified":1690856397,
+    "wof:lastmodified":1695886581,
     "wof:name":"Huy",
     "wof:parent_id":85681691,
     "wof:placetype":"county",

--- a/data/102/049/927/102049927.geojson
+++ b/data/102/049/927/102049927.geojson
@@ -311,9 +311,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"352",
         "eurostat:nuts_2021_id":"BE32B",
         "hasc:id":"BE.HT.CR"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"2dbe5ed6e8a38a9925145e19cb3551d6",
     "wof:hierarchy":[
@@ -326,7 +331,7 @@
         }
     ],
     "wof:id":102049927,
-    "wof:lastmodified":1684351492,
+    "wof:lastmodified":1695886581,
     "wof:name":"Charleroi",
     "wof:parent_id":85681723,
     "wof:placetype":"county",

--- a/data/102/049/931/102049931.geojson
+++ b/data/102/049/931/102049931.geojson
@@ -347,12 +347,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"392",
         "eurostat:nuts_2021_id":"BE352",
         "hasc:id":"BE.NA.NM",
         "wd:id":"Q1125"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"7f771347053dbc314ac6639746627c59",
+    "wof:geomhash":"e36464ceefec68786d0ac958750cda4c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -363,7 +368,7 @@
         }
     ],
     "wof:id":102049931,
-    "wof:lastmodified":1690856394,
+    "wof:lastmodified":1695886581,
     "wof:name":"Namur",
     "wof:parent_id":85681699,
     "wof:placetype":"county",

--- a/data/102/049/933/102049933.geojson
+++ b/data/102/049/933/102049933.geojson
@@ -299,9 +299,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"353",
         "eurostat:nuts_2021_id":"BE323",
         "hasc:id":"BE.HT.MN"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"068652778e16e245bb30c4a7e9695181",
     "wof:hierarchy":[
@@ -314,7 +319,7 @@
         }
     ],
     "wof:id":102049933,
-    "wof:lastmodified":1684351493,
+    "wof:lastmodified":1695886581,
     "wof:name":"Mons",
     "wof:parent_id":85681723,
     "wof:placetype":"county",

--- a/data/102/049/935/102049935.geojson
+++ b/data/102/049/935/102049935.geojson
@@ -276,12 +276,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"363",
         "eurostat:nuts_2021_id":"BE335",
         "hasc:id":"BE.LG.VV",
         "wd:id":"Q202954"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"b17bc4162b3d83a3beec80c57bffbb1a",
+    "wof:geomhash":"2fa700e987b8ce0ca1d8d3a4da096fbb",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -292,7 +297,7 @@
         }
     ],
     "wof:id":102049935,
-    "wof:lastmodified":1690856398,
+    "wof:lastmodified":1695886581,
     "wof:name":"Verviers",
     "wof:parent_id":85681691,
     "wof:placetype":"county",

--- a/data/102/049/937/102049937.geojson
+++ b/data/102/049/937/102049937.geojson
@@ -216,12 +216,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"364",
         "eurostat:nuts_2021_id":"BE334",
         "hasc:id":"BE.LG.WR",
         "wd:id":"Q711474"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"65cb415973d969330a220818a03dd7af",
+    "wof:geomhash":"0ac21c61ffee218f8424057adb1b2820",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -232,7 +237,7 @@
         }
     ],
     "wof:id":102049937,
-    "wof:lastmodified":1690856395,
+    "wof:lastmodified":1695886581,
     "wof:name":"Waremme",
     "wof:parent_id":85681691,
     "wof:placetype":"county",

--- a/data/102/049/941/102049941.geojson
+++ b/data/102/049/941/102049941.geojson
@@ -353,12 +353,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"362",
         "eurostat:nuts_2021_id":"BE332",
         "hasc:id":"BE.LG.LG",
         "wd:id":"Q1127"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"f1eddb65b59b91458313eca18a6f9017",
+    "wof:geomhash":"2d3f99e33f940a34fd6e441595697b2e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -369,7 +374,7 @@
         }
     ],
     "wof:id":102049941,
-    "wof:lastmodified":1690856397,
+    "wof:lastmodified":1695886581,
     "wof:name":"Li\u00e8ge",
     "wof:parent_id":85681691,
     "wof:placetype":"county",

--- a/data/102/049/943/102049943.geojson
+++ b/data/102/049/943/102049943.geojson
@@ -240,12 +240,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"355",
         "eurostat:nuts_2021_id":"BE32C",
         "hasc:id":"BE.HT.SG",
         "wd:id":"Q462985"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"dc2a51a172811b8fb2f39b4ad5476cd9",
+    "wof:geomhash":"8906e77684c0d2eec528498a4ee2b977",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -256,7 +261,7 @@
         }
     ],
     "wof:id":102049943,
-    "wof:lastmodified":1690856401,
+    "wof:lastmodified":1695886582,
     "wof:name":"Soignies",
     "wof:parent_id":85681723,
     "wof:placetype":"county",

--- a/data/102/049/945/102049945.geojson
+++ b/data/102/049/945/102049945.geojson
@@ -237,12 +237,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"325",
         "eurostat:nuts_2021_id":"BE310",
         "hasc:id":"BE.BW.NV",
         "wd:id":"Q319463"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"625447c80acc1c2e4a5ed7ee6f5e8d92",
+    "wof:geomhash":"102f902d3e450b0409f6f7c2b621b628",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -253,7 +258,7 @@
         }
     ],
     "wof:id":102049945,
-    "wof:lastmodified":1690856399,
+    "wof:lastmodified":1695886582,
     "wof:name":"Nivelles",
     "wof:parent_id":85681693,
     "wof:placetype":"county",

--- a/data/102/049/949/102049949.geojson
+++ b/data/102/049/949/102049949.geojson
@@ -237,12 +237,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"351",
         "eurostat:nuts_2021_id":"BE32A",
         "hasc:id":"BE.HT.AT",
         "wd:id":"Q95096"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"ecd36d9730d3cee0bfc8cc8d76ff07ed",
+    "wof:geomhash":"05ce4bd697edd1278ae5266c32902e6c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -253,7 +258,7 @@
         }
     ],
     "wof:id":102049949,
-    "wof:lastmodified":1690856397,
+    "wof:lastmodified":1695886582,
     "wof:name":"Ath",
     "wof:parent_id":85681723,
     "wof:placetype":"county",

--- a/data/102/049/951/102049951.geojson
+++ b/data/102/049/951/102049951.geojson
@@ -302,12 +302,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"357",
         "eurostat:nuts_2021_id":"BE328",
         "hasc:id":"BE.HT.TR",
         "wd:id":"Q173219"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"471c085157517fff1ec6502a29ff3114",
+    "wof:geomhash":"3ebfe16fb5e72646aea6d23d4f49b677",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -318,7 +323,7 @@
         }
     ],
     "wof:id":102049951,
-    "wof:lastmodified":1690856399,
+    "wof:lastmodified":1695886582,
     "wof:name":"Tournai",
     "wof:parent_id":85681723,
     "wof:placetype":"county",

--- a/data/102/049/961/102049961.geojson
+++ b/data/102/049/961/102049961.geojson
@@ -299,9 +299,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"234",
         "eurostat:nuts_2021_id":"BE254",
         "hasc:id":"BE.WV.KR"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"b42ac57af24acc989cc75217ec14e8c8",
     "wof:hierarchy":[
@@ -314,7 +319,7 @@
         }
     ],
     "wof:id":102049961,
-    "wof:lastmodified":1684351493,
+    "wof:lastmodified":1695886582,
     "wof:name":"Kortrijk",
     "wof:parent_id":85681709,
     "wof:placetype":"county",

--- a/data/102/049/963/102049963.geojson
+++ b/data/102/049/963/102049963.geojson
@@ -270,12 +270,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"245",
         "eurostat:nuts_2021_id":"BE235",
         "hasc:id":"BE.OV.OD",
         "wd:id":"Q12992"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"99a530b761d466cd16ec5a50ec039ba3",
+    "wof:geomhash":"88fa1b34bec5448e816e4ab7fb8be453",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -286,7 +291,7 @@
         }
     ],
     "wof:id":102049963,
-    "wof:lastmodified":1690856396,
+    "wof:lastmodified":1695886582,
     "wof:name":"Oudenaarde",
     "wof:parent_id":85681733,
     "wof:placetype":"county",

--- a/data/102/049/967/102049967.geojson
+++ b/data/102/049/967/102049967.geojson
@@ -147,9 +147,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"241",
         "eurostat:nuts_2021_id":"BE231",
         "hasc:id":"BE.OV.AL"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"d186590f8a6924e9ecd77d88c7e84dec",
     "wof:hierarchy":[
@@ -162,7 +167,7 @@
         }
     ],
     "wof:id":102049967,
-    "wof:lastmodified":1684351493,
+    "wof:lastmodified":1695886582,
     "wof:name":"Aalst",
     "wof:parent_id":85681733,
     "wof:placetype":"county",

--- a/data/102/049/969/102049969.geojson
+++ b/data/102/049/969/102049969.geojson
@@ -290,9 +290,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"224",
         "eurostat:nuts_2021_id":"BE242",
         "hasc:id":"BE.VB.LV"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"b1c8de842cfbce3108ca0686a9f0aed1",
     "wof:hierarchy":[
@@ -305,7 +310,7 @@
         }
     ],
     "wof:id":102049969,
-    "wof:lastmodified":1684351493,
+    "wof:lastmodified":1695886582,
     "wof:name":"Leuven",
     "wof:parent_id":85681731,
     "wof:placetype":"county",

--- a/data/102/049/971/102049971.geojson
+++ b/data/102/049/971/102049971.geojson
@@ -110,9 +110,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"233",
         "eurostat:nuts_2021_id":"BE253",
         "hasc:id":"BE.WV.IP"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"a45f90b8ff4d62c941e780cf34cd29e5",
     "wof:hierarchy":[
@@ -125,7 +130,7 @@
         }
     ],
     "wof:id":102049971,
-    "wof:lastmodified":1684351493,
+    "wof:lastmodified":1695886583,
     "wof:name":"Ieper",
     "wof:parent_id":85681709,
     "wof:placetype":"county",

--- a/data/102/049/973/102049973.geojson
+++ b/data/102/049/973/102049973.geojson
@@ -110,9 +110,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"223",
         "eurostat:nuts_2021_id":"BE241",
         "hasc:id":"BE.VB.HV"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"b7776d21bb9d856dcd7423721ad9d094",
     "wof:hierarchy":[
@@ -125,7 +130,7 @@
         }
     ],
     "wof:id":102049973,
-    "wof:lastmodified":1684351493,
+    "wof:lastmodified":1695886583,
     "wof:name":"Halle-Vilvoorde",
     "wof:parent_id":85681731,
     "wof:placetype":"county",

--- a/data/102/049/975/102049975.geojson
+++ b/data/102/049/975/102049975.geojson
@@ -284,9 +284,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"271",
         "eurostat:nuts_2021_id":"BE224",
         "hasc:id":"BE.LI.HS"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"700a602a8bdb1d7f62fbc80cc0eaf767",
     "wof:hierarchy":[
@@ -299,7 +304,7 @@
         }
     ],
     "wof:id":102049975,
-    "wof:lastmodified":1684351493,
+    "wof:lastmodified":1695886583,
     "wof:name":"Hasselt",
     "wof:parent_id":85681705,
     "wof:placetype":"county",

--- a/data/102/049/977/102049977.geojson
+++ b/data/102/049/977/102049977.geojson
@@ -276,12 +276,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"236",
         "eurostat:nuts_2021_id":"BE256",
         "hasc:id":"BE.WV.RS",
         "wd:id":"Q211037"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"803d2f5be468a2f57c7fc8def2b635f7",
+    "wof:geomhash":"565adad30ef83db1a92c8aa650608f09",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -292,7 +297,7 @@
         }
     ],
     "wof:id":102049977,
-    "wof:lastmodified":1690856396,
+    "wof:lastmodified":1695886583,
     "wof:name":"Roeselare",
     "wof:parent_id":85681709,
     "wof:placetype":"county",

--- a/data/102/049/979/102049979.geojson
+++ b/data/102/049/979/102049979.geojson
@@ -239,9 +239,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"242",
         "eurostat:nuts_2021_id":"BE232",
         "hasc:id":"BE.OV.DM"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"be33a06b137e27fc84378653b65d7fde",
     "wof:hierarchy":[
@@ -254,7 +259,7 @@
         }
     ],
     "wof:id":102049979,
-    "wof:lastmodified":1684351493,
+    "wof:lastmodified":1695886583,
     "wof:name":"Dendermonde",
     "wof:parent_id":85681733,
     "wof:placetype":"county",

--- a/data/102/049/981/102049981.geojson
+++ b/data/102/049/981/102049981.geojson
@@ -237,12 +237,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"237",
         "eurostat:nuts_2021_id":"BE257",
         "hasc:id":"BE.WV.TL",
         "wd:id":"Q651811"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"2c8a7da23260fbeab806859c95d1e823",
+    "wof:geomhash":"47d5d61b1efd7c0edcf6952d43399657",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -253,7 +258,7 @@
         }
     ],
     "wof:id":102049981,
-    "wof:lastmodified":1690856401,
+    "wof:lastmodified":1695886583,
     "wof:name":"Tielt",
     "wof:parent_id":85681709,
     "wof:placetype":"county",

--- a/data/102/049/985/102049985.geojson
+++ b/data/102/049/985/102049985.geojson
@@ -275,9 +275,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"212",
         "eurostat:nuts_2021_id":"BE212",
         "hasc:id":"BE.AN.MH"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"284e615822d9503431515facaf75a304",
     "wof:hierarchy":[
@@ -290,7 +295,7 @@
         }
     ],
     "wof:id":102049985,
-    "wof:lastmodified":1684351493,
+    "wof:lastmodified":1695886583,
     "wof:name":"Mechelen",
     "wof:parent_id":85681715,
     "wof:placetype":"county",

--- a/data/102/049/987/102049987.geojson
+++ b/data/102/049/987/102049987.geojson
@@ -348,12 +348,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"232",
         "eurostat:nuts_2021_id":"BE252",
         "hasc:id":"BE.WV.DK",
         "wd:id":"Q215244"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"a1e293505f193a20563c717c8999f49e",
+    "wof:geomhash":"e9860505d59e167adcec19d0c2ca21f4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -364,7 +369,7 @@
         }
     ],
     "wof:id":102049987,
-    "wof:lastmodified":1690856399,
+    "wof:lastmodified":1695886584,
     "wof:name":"Diksmuide",
     "wof:parent_id":85681709,
     "wof:placetype":"county",

--- a/data/102/049/989/102049989.geojson
+++ b/data/102/049/989/102049989.geojson
@@ -129,9 +129,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"244",
         "eurostat:nuts_2021_id":"BE234",
         "hasc:id":"BE.OV.GT"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"16c792db67a4d26501559a95c5b99456",
     "wof:hierarchy":[
@@ -144,7 +149,7 @@
         }
     ],
     "wof:id":102049989,
-    "wof:lastmodified":1684351493,
+    "wof:lastmodified":1695886584,
     "wof:name":"Gent",
     "wof:parent_id":85681733,
     "wof:placetype":"county",

--- a/data/102/049/991/102049991.geojson
+++ b/data/102/049/991/102049991.geojson
@@ -231,12 +231,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"238",
         "eurostat:nuts_2021_id":"BE258",
         "hasc:id":"BE.WV.VR",
         "wd:id":"Q506707"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"8526e9dbdfdd6b5784022fef31ce2f5f",
+    "wof:geomhash":"b6c703866c0840b3e1fffaf92d4d094e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -247,7 +252,7 @@
         }
     ],
     "wof:id":102049991,
-    "wof:lastmodified":1690856395,
+    "wof:lastmodified":1695886584,
     "wof:name":"Veurne",
     "wof:parent_id":85681709,
     "wof:placetype":"county",

--- a/data/102/049/993/102049993.geojson
+++ b/data/102/049/993/102049993.geojson
@@ -246,12 +246,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"272",
         "eurostat:nuts_2021_id":"BE225",
         "hasc:id":"BE.LI.MS",
         "wd:id":"Q110989"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"67c87f3301df456604073adc5b04026b",
+    "wof:geomhash":"8c135421824b49e01b979e64fbd65288",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -262,7 +267,7 @@
         }
     ],
     "wof:id":102049993,
-    "wof:lastmodified":1690856398,
+    "wof:lastmodified":1695886584,
     "wof:name":"Maaseik",
     "wof:parent_id":85681705,
     "wof:placetype":"county",

--- a/data/102/049/995/102049995.geojson
+++ b/data/102/049/995/102049995.geojson
@@ -225,12 +225,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"243",
         "eurostat:nuts_2021_id":"BE233",
         "hasc:id":"BE.OV.EK",
         "wd:id":"Q12440"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"58565809aca245546587bbefb8aab13f",
+    "wof:geomhash":"e29d0bafa5f3bd1dcb609ae982058821",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -241,7 +246,7 @@
         }
     ],
     "wof:id":102049995,
-    "wof:lastmodified":1690856398,
+    "wof:lastmodified":1695886584,
     "wof:name":"Eeklo",
     "wof:parent_id":85681733,
     "wof:placetype":"county",

--- a/data/102/049/997/102049997.geojson
+++ b/data/102/049/997/102049997.geojson
@@ -245,9 +245,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"246",
         "eurostat:nuts_2021_id":"BE236",
         "hasc:id":"BE.OV.SN"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"b04e651f1184ccfcc7e98bf20d43b7cd",
     "wof:hierarchy":[
@@ -260,7 +265,7 @@
         }
     ],
     "wof:id":102049997,
-    "wof:lastmodified":1684351494,
+    "wof:lastmodified":1695886584,
     "wof:name":"Sint-Niklaas",
     "wof:parent_id":85681733,
     "wof:placetype":"county",

--- a/data/102/049/999/102049999.geojson
+++ b/data/102/049/999/102049999.geojson
@@ -324,12 +324,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"235",
         "eurostat:nuts_2021_id":"BE255",
         "hasc:id":"BE.WV.OS",
         "wd:id":"Q12996"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"043a1ff394568cdc694001d3f28fa902",
+    "wof:geomhash":"d2cb78ebbfc65aa02b3cf4feb5ee237b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -340,7 +345,7 @@
         }
     ],
     "wof:id":102049999,
-    "wof:lastmodified":1690856396,
+    "wof:lastmodified":1695886584,
     "wof:name":"Oostende",
     "wof:parent_id":85681709,
     "wof:placetype":"county",

--- a/data/102/050/003/102050003.geojson
+++ b/data/102/050/003/102050003.geojson
@@ -110,9 +110,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"231",
         "eurostat:nuts_2021_id":"BE251",
         "hasc:id":"BE.WV.BG"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"99991cb5db4c3f4431d4db1713cc106a",
     "wof:hierarchy":[
@@ -125,7 +130,7 @@
         }
     ],
     "wof:id":102050003,
-    "wof:lastmodified":1684351494,
+    "wof:lastmodified":1695886584,
     "wof:name":"Brugge",
     "wof:parent_id":85681709,
     "wof:placetype":"county",

--- a/data/102/050/005/102050005.geojson
+++ b/data/102/050/005/102050005.geojson
@@ -374,12 +374,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"211",
         "eurostat:nuts_2021_id":"BE211",
         "hasc:id":"BE.AN.AW",
         "wd:id":"Q1116"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"c5686778f71a301cecefe13a48462e9b",
+    "wof:geomhash":"eb1cb22d6b7ff8be37ca16c74b865ec4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -390,7 +395,7 @@
         }
     ],
     "wof:id":102050005,
-    "wof:lastmodified":1690856402,
+    "wof:lastmodified":1695886585,
     "wof:name":"Antwerpen",
     "wof:parent_id":85681715,
     "wof:placetype":"county",

--- a/data/102/050/007/102050007.geojson
+++ b/data/102/050/007/102050007.geojson
@@ -251,12 +251,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"213",
         "eurostat:nuts_2021_id":"BE213",
         "hasc:id":"BE.AN.TH",
         "wd:id":"Q271783"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"6ec0e50898321f4ff8920bed0e613663",
+    "wof:geomhash":"fc6495bd7a212ec53911d70ca3fbb5df",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -267,7 +272,7 @@
         }
     ],
     "wof:id":102050007,
-    "wof:lastmodified":1690856401,
+    "wof:lastmodified":1695886585,
     "wof:name":"Turnhout",
     "wof:parent_id":85681715,
     "wof:placetype":"county",

--- a/data/110/878/255/9/1108782559.geojson
+++ b/data/110/878/255/9/1108782559.geojson
@@ -58,7 +58,7 @@
     "mps:latitude":50.7285,
     "mps:longitude":2.905331,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:bel_x_preferred":[
         "\u041c\u0443\u0441\u043a\u0440\u043e\u043d"
@@ -248,12 +248,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"354",
         "eurostat:nuts_2021_id":"TR611",
         "hasc:id":"BE.HT.MC",
         "wd:id":"Q220145"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"0699a681e9db275dafbc4f206f78ab42",
+    "wof:geomhash":"57c309c7b87032cd61107cab9074edbe",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -264,7 +269,7 @@
         }
     ],
     "wof:id":1108782559,
-    "wof:lastmodified":1690856433,
+    "wof:lastmodified":1695887184,
     "wof:name":"Mouscron",
     "wof:parent_id":85681723,
     "wof:placetype":"county",

--- a/data/110/878/256/3/1108782563.geojson
+++ b/data/110/878/256/3/1108782563.geojson
@@ -58,7 +58,7 @@
     "mps:latitude":50.822513,
     "mps:longitude":5.493739,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:afr_x_preferred":[
         "Tongeren"
@@ -245,12 +245,17 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"273",
         "eurostat:nuts_2021_id":"BE223",
         "hasc:id":"BE.LI.TG",
         "wd:id":"Q190113"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"dae60af10c8beb5408e38f15ac423a04",
+    "wof:geomhash":"d72a252ac0eff35935713e4163e288aa",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -261,7 +266,7 @@
         }
     ],
     "wof:id":1108782563,
-    "wof:lastmodified":1690856432,
+    "wof:lastmodified":1695887184,
     "wof:name":"Tongeren",
     "wof:parent_id":85681705,
     "wof:placetype":"county",

--- a/data/110/883/000/5/1108830005.geojson
+++ b/data/110/883/000/5/1108830005.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.293265,
     "geom:longitude":4.713517,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.303591,
     "lbl:longitude":4.702717,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Malle"
@@ -119,9 +131,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11057",
         "eg:gisco_id":"BE_11057",
         "eurostat:nuts_2021_id":"11057"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241095,
     "wof:geomhash":"2822bc25756efeb0cdceff89e331c89d",
@@ -136,7 +150,7 @@
         }
     ],
     "wof:id":1108830005,
-    "wof:lastmodified":1684351648,
+    "wof:lastmodified":1695878062,
     "wof:name":"Malle",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/000/7/1108830007.geojson
+++ b/data/110/883/000/7/1108830007.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.062408,
     "geom:longitude":4.536334,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.067186,
     "lbl:longitude":4.531356,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Sint-Katelijne-Waver"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"12035",
         "eg:gisco_id":"BE_12035",
         "eurostat:nuts_2021_id":"12035"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241095,
     "wof:geomhash":"fd3de59821dc3dac9bc32586859910b2",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830007,
-    "wof:lastmodified":1684351649,
+    "wof:lastmodified":1695878062,
     "wof:name":"Sint-Katelijne-Waver",
     "wof:parent_id":102049985,
     "wof:placetype":"localadmin",

--- a/data/110/883/000/9/1108830009.geojson
+++ b/data/110/883/000/9/1108830009.geojson
@@ -14,17 +14,29 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003108,
-    "geom:area_square_m":24230773.811383,
+    "geom:area_square_m":24230773.811384,
     "geom:bbox":"3.56372889733,50.8823570105,3.68677426917,50.9401629841",
     "geom:latitude":50.908348,
     "geom:longitude":3.622255,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.916732,
     "lbl:longitude":3.605919,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Zingem"
@@ -110,10 +122,13 @@
         102049963
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "begov:niscode":"45057"
+    },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241096,
-    "wof:geomhash":"2b03eacb230e76788b3abac74d36ef32",
+    "wof:geomhash":"c988d3641555bc8d339e26be7ea27c42",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -125,7 +140,7 @@
         }
     ],
     "wof:id":1108830009,
-    "wof:lastmodified":1566611558,
+    "wof:lastmodified":1695878060,
     "wof:name":"Zingem",
     "wof:parent_id":102049963,
     "wof:placetype":"localadmin",

--- a/data/110/883/001/1/1108830011.geojson
+++ b/data/110/883/001/1/1108830011.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.842649,
     "geom:longitude":5.323424,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.845269,
     "lbl:longitude":5.32423,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Wellen"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"73098",
         "eg:gisco_id":"BE_73098",
         "eurostat:nuts_2021_id":"73098"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241096,
     "wof:geomhash":"f09b7845f694344f723d294d05793efa",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830011,
-    "wof:lastmodified":1684351649,
+    "wof:lastmodified":1695878062,
     "wof:name":"Wellen",
     "wof:parent_id":1108782563,
     "wof:placetype":"localadmin",

--- a/data/110/883/001/3/1108830013.geojson
+++ b/data/110/883/001/3/1108830013.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.131828,
     "geom:longitude":4.382529,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.131251,
     "lbl:longitude":4.385791,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Aartselaar"
@@ -146,9 +158,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11001",
         "eg:gisco_id":"BE_11001",
         "eurostat:nuts_2021_id":"11001"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241097,
     "wof:geomhash":"dc6fb0b761483d6172f8bbfe391b8099",
@@ -163,7 +177,7 @@
         }
     ],
     "wof:id":1108830013,
-    "wof:lastmodified":1684351649,
+    "wof:lastmodified":1695878063,
     "wof:name":"Aartselaar",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/001/7/1108830017.geojson
+++ b/data/110/883/001/7/1108830017.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.811964,
     "geom:longitude":4.941882,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.802072,
     "lbl:longitude":4.950154,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Tienen"
@@ -143,9 +155,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24107",
         "eg:gisco_id":"BE_24107",
         "eurostat:nuts_2021_id":"24107"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241097,
     "wof:geomhash":"5715082e3bc987494ddbc1e5e3830239",
@@ -160,7 +174,7 @@
         }
     ],
     "wof:id":1108830017,
-    "wof:lastmodified":1684351649,
+    "wof:lastmodified":1695878063,
     "wof:name":"Tienen",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/001/9/1108830019.geojson
+++ b/data/110/883/001/9/1108830019.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.867663,
     "geom:longitude":3.805528,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.859713,
     "lbl:longitude":3.806448,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Zottegem"
@@ -140,9 +152,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"41081",
         "eg:gisco_id":"BE_41081",
         "eurostat:nuts_2021_id":"41081"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241097,
     "wof:geomhash":"cd0ba83c0e5377aeb60d1161ff0b75f7",
@@ -157,7 +171,7 @@
         }
     ],
     "wof:id":1108830019,
-    "wof:lastmodified":1684351649,
+    "wof:lastmodified":1695878063,
     "wof:name":"Zottegem",
     "wof:parent_id":102049967,
     "wof:placetype":"localadmin",

--- a/data/110/883/002/1/1108830021.geojson
+++ b/data/110/883/002/1/1108830021.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.745354,
     "geom:longitude":5.822685,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.736436,
     "lbl:longitude":5.830479,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Voeren"
@@ -149,9 +161,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"73109",
         "eg:gisco_id":"BE_73109",
         "eurostat:nuts_2021_id":"73109"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241098,
     "wof:geomhash":"6bbbb74c5543523c2bef7419a5692692",
@@ -166,7 +180,7 @@
         }
     ],
     "wof:id":1108830021,
-    "wof:lastmodified":1684351649,
+    "wof:lastmodified":1695878064,
     "wof:name":"Voeren",
     "wof:parent_id":1108782563,
     "wof:placetype":"localadmin",

--- a/data/110/883/002/3/1108830023.geojson
+++ b/data/110/883/002/3/1108830023.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.071647,
     "geom:longitude":4.736039,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.06948,
     "lbl:longitude":4.728238,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Heist-op-den-Berg"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"12014",
         "eg:gisco_id":"BE_12014",
         "eurostat:nuts_2021_id":"12014"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241098,
     "wof:geomhash":"d0325ca882b2b50e907c6951effd63f7",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830023,
-    "wof:lastmodified":1684351649,
+    "wof:lastmodified":1695878064,
     "wof:name":"Heist-op-den-Berg",
     "wof:parent_id":102049985,
     "wof:placetype":"localadmin",

--- a/data/110/883/002/5/1108830025.geojson
+++ b/data/110/883/002/5/1108830025.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.789739,
     "geom:longitude":4.611934,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.800125,
     "lbl:longitude":4.607011,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Huldenberg"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24045",
         "eg:gisco_id":"BE_24045",
         "eurostat:nuts_2021_id":"24045"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241098,
     "wof:geomhash":"a32a265c0400f480beb945de5e5327ef",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830025,
-    "wof:lastmodified":1684351650,
+    "wof:lastmodified":1695878064,
     "wof:name":"Huldenberg",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/002/7/1108830027.geojson
+++ b/data/110/883/002/7/1108830027.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.042422,
     "geom:longitude":3.884212,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.043138,
     "lbl:longitude":3.900405,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Laarne"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"42010",
         "eg:gisco_id":"BE_42010",
         "eurostat:nuts_2021_id":"42010"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241099,
     "wof:geomhash":"1ea2520a8fa1836109771753171dc162",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830027,
-    "wof:lastmodified":1684351650,
+    "wof:lastmodified":1695878065,
     "wof:name":"Laarne",
     "wof:parent_id":102049979,
     "wof:placetype":"localadmin",

--- a/data/110/883/002/9/1108830029.geojson
+++ b/data/110/883/002/9/1108830029.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.860978,
     "geom:longitude":2.691352,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.86355,
     "lbl:longitude":2.664404,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Poperinge"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"33021",
         "eg:gisco_id":"BE_33021",
         "eurostat:nuts_2021_id":"33021"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241099,
     "wof:geomhash":"cd1f0aa047c5e190bfd11bc8c3f65a94",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830029,
-    "wof:lastmodified":1684351650,
+    "wof:lastmodified":1695878065,
     "wof:name":"Poperinge",
     "wof:parent_id":102049971,
     "wof:placetype":"localadmin",

--- a/data/110/883/003/1/1108830031.geojson
+++ b/data/110/883/003/1/1108830031.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.771781,
     "geom:longitude":5.464415,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.776521,
     "lbl:longitude":5.464377,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Tongeren"
@@ -185,9 +197,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"73083",
         "eg:gisco_id":"BE_73083",
         "eurostat:nuts_2021_id":"73083"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241099,
     "wof:geomhash":"7ae7669e8d698caceb82ec1c60b7afcf",
@@ -202,7 +216,7 @@
         }
     ],
     "wof:id":1108830031,
-    "wof:lastmodified":1684351650,
+    "wof:lastmodified":1695878065,
     "wof:name":"Tongeren",
     "wof:parent_id":1108782563,
     "wof:placetype":"localadmin",

--- a/data/110/883/003/5/1108830035.geojson
+++ b/data/110/883/003/5/1108830035.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.9992,
     "geom:longitude":4.726752,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.001322,
     "lbl:longitude":4.726749,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Tremelo"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24109",
         "eg:gisco_id":"BE_24109",
         "eurostat:nuts_2021_id":"24109"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241101,
     "wof:geomhash":"3a6c1808b257723e21be6ce0104a8166",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830035,
-    "wof:lastmodified":1684351650,
+    "wof:lastmodified":1695878066,
     "wof:name":"Tremelo",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/003/7/1108830037.geojson
+++ b/data/110/883/003/7/1108830037.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.96114,
     "geom:longitude":4.315651,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.961093,
     "lbl:longitude":4.316433,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Meise"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23050",
         "eg:gisco_id":"BE_23050",
         "eurostat:nuts_2021_id":"23050"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241101,
     "wof:geomhash":"6cafe7b98df1b7ec318658d872f67716",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830037,
-    "wof:lastmodified":1684351650,
+    "wof:lastmodified":1695878066,
     "wof:name":"Meise",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/003/9/1108830039.geojson
+++ b/data/110/883/003/9/1108830039.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.003622,
     "geom:longitude":4.354735,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.00106,
     "lbl:longitude":4.354198,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bar_x_preferred":[
         "Kapelle-op-den-Bos"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23039",
         "eg:gisco_id":"BE_23039",
         "eurostat:nuts_2021_id":"23039"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241102,
     "wof:geomhash":"3424a244861febe4106343d0152424bb",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830039,
-    "wof:lastmodified":1684351651,
+    "wof:lastmodified":1695878066,
     "wof:name":"Kapelle-op-den-Bos",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/004/1/1108830041.geojson
+++ b/data/110/883/004/1/1108830041.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.981618,
     "geom:longitude":3.203099,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.976537,
     "lbl:longitude":3.202327,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Ardooie"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"37020",
         "eg:gisco_id":"BE_37020",
         "eurostat:nuts_2021_id":"37020"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241102,
     "wof:geomhash":"bba66e727182c17c85c6d9d793abd32f",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830041,
-    "wof:lastmodified":1684351651,
+    "wof:lastmodified":1695878067,
     "wof:name":"Ardooie",
     "wof:parent_id":102049981,
     "wof:placetype":"localadmin",

--- a/data/110/883/004/3/1108830043.geojson
+++ b/data/110/883/004/3/1108830043.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.820007,
     "geom:longitude":4.686902,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.809748,
     "lbl:longitude":4.681268,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Oud-Heverlee"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24086",
         "eg:gisco_id":"BE_24086",
         "eurostat:nuts_2021_id":"24086"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241103,
     "wof:geomhash":"128a9b53edf4ee4d18168dd307bd4e75",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830043,
-    "wof:lastmodified":1684351651,
+    "wof:lastmodified":1695878067,
     "wof:name":"Oud-Heverlee",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/004/5/1108830045.geojson
+++ b/data/110/883/004/5/1108830045.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.820787,
     "geom:longitude":5.041996,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.819667,
     "lbl:longitude":5.04544,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Linter"
@@ -119,9 +131,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24133",
         "eg:gisco_id":"BE_24133",
         "eurostat:nuts_2021_id":"24133"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241103,
     "wof:geomhash":"ba2ec400de748fce6b80611cf77f1754",
@@ -136,7 +150,7 @@
         }
     ],
     "wof:id":1108830045,
-    "wof:lastmodified":1684351651,
+    "wof:lastmodified":1695878067,
     "wof:name":"Linter",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/004/7/1108830047.geojson
+++ b/data/110/883/004/7/1108830047.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.103093,
     "geom:longitude":3.85712,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.11173,
     "lbl:longitude":3.863805,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Lochristi"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"44034",
         "eg:gisco_id":"BE_44034",
         "eurostat:nuts_2021_id":"44034"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241103,
     "wof:geomhash":"155b20c7fd42cf8d569e9a47871d96af",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830047,
-    "wof:lastmodified":1684351651,
+    "wof:lastmodified":1695878067,
     "wof:name":"Lochristi",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/004/9/1108830049.geojson
+++ b/data/110/883/004/9/1108830049.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.020817,
     "geom:longitude":4.570733,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.018273,
     "lbl:longitude":4.56525,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Bonheiden"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"12005",
         "eg:gisco_id":"BE_12005",
         "eurostat:nuts_2021_id":"12005"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241104,
     "wof:geomhash":"a05c6d9ddedecf94dd210b338a8d1ef8",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830049,
-    "wof:lastmodified":1684351651,
+    "wof:lastmodified":1695878067,
     "wof:name":"Bonheiden",
     "wof:parent_id":102049985,
     "wof:placetype":"localadmin",

--- a/data/110/883/005/3/1108830053.geojson
+++ b/data/110/883/005/3/1108830053.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.010584,
     "geom:longitude":4.276416,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.011391,
     "lbl:longitude":4.276406,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Londerzeel"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23045",
         "eg:gisco_id":"BE_23045",
         "eurostat:nuts_2021_id":"23045"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241104,
     "wof:geomhash":"340abe5ae36c5b358253180a1a2281bb",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830053,
-    "wof:lastmodified":1684351651,
+    "wof:lastmodified":1695878068,
     "wof:name":"Londerzeel",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/005/5/1108830055.geojson
+++ b/data/110/883/005/5/1108830055.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.005217,
     "geom:longitude":4.654314,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.006677,
     "lbl:longitude":4.655142,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Keerbergen"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24048",
         "eg:gisco_id":"BE_24048",
         "eurostat:nuts_2021_id":"24048"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241104,
     "wof:geomhash":"388415e36140fec072e93ff42a853bfd",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830055,
-    "wof:lastmodified":1684351652,
+    "wof:lastmodified":1695878068,
     "wof:name":"Keerbergen",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/005/7/1108830057.geojson
+++ b/data/110/883/005/7/1108830057.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.112667,
     "geom:longitude":3.030812,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.111126,
     "lbl:longitude":3.030091,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Ichtegem"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"35006",
         "eg:gisco_id":"BE_35006",
         "eurostat:nuts_2021_id":"35006"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241105,
     "wof:geomhash":"a799306822253fdc159cb11afa6efdba",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830057,
-    "wof:lastmodified":1684351652,
+    "wof:lastmodified":1695878068,
     "wof:name":"Ichtegem",
     "wof:parent_id":102049999,
     "wof:placetype":"localadmin",

--- a/data/110/883/005/9/1108830059.geojson
+++ b/data/110/883/005/9/1108830059.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.18045,
     "geom:longitude":3.873289,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.179198,
     "lbl:longitude":3.86775,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Wachtebeke"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"44073",
         "eg:gisco_id":"BE_44073",
         "eurostat:nuts_2021_id":"44073"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241105,
     "wof:geomhash":"f75778e21ffba3abf5a8d9be93ce03c7",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830059,
-    "wof:lastmodified":1684351652,
+    "wof:lastmodified":1695878068,
     "wof:name":"Wachtebeke",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/006/1/1108830061.geojson
+++ b/data/110/883/006/1/1108830061.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.163824,
     "geom:longitude":4.827624,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.173771,
     "lbl:longitude":4.824001,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Herentals"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13011",
         "eg:gisco_id":"BE_13011",
         "eurostat:nuts_2021_id":"13011"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241105,
     "wof:geomhash":"c5a521a5491595130b17e30332aae178",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830061,
-    "wof:lastmodified":1684351652,
+    "wof:lastmodified":1695878069,
     "wof:name":"Herentals",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/006/3/1108830063.geojson
+++ b/data/110/883/006/3/1108830063.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.252215,
     "geom:longitude":3.32741,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.257797,
     "lbl:longitude":3.333597,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u062f\u0627\u0645\u0647"
@@ -143,9 +155,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"31006",
         "eg:gisco_id":"BE_31006",
         "eurostat:nuts_2021_id":"31006"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241106,
     "wof:geomhash":"41666999da0c9a77e4f7070cc347ded3",
@@ -160,7 +174,7 @@
         }
     ],
     "wof:id":1108830063,
-    "wof:lastmodified":1684351652,
+    "wof:lastmodified":1695878069,
     "wof:name":"Damme",
     "wof:parent_id":102050003,
     "wof:placetype":"localadmin",

--- a/data/110/883/006/5/1108830065.geojson
+++ b/data/110/883/006/5/1108830065.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.059502,
     "geom:longitude":3.259937,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.063668,
     "lbl:longitude":3.27446,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Wingene"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"37018",
         "eg:gisco_id":"BE_37018",
         "eurostat:nuts_2021_id":"37018"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241106,
     "wof:geomhash":"045d8d6902c8eeeda84c0f5851eb21be",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830065,
-    "wof:lastmodified":1684351652,
+    "wof:lastmodified":1695878069,
     "wof:name":"Wingene",
     "wof:parent_id":102049981,
     "wof:placetype":"localadmin",

--- a/data/110/883/006/7/1108830067.geojson
+++ b/data/110/883/006/7/1108830067.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.792453,
     "geom:longitude":3.154425,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.777644,
     "lbl:longitude":3.18225,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Menen"
@@ -146,9 +158,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"34027",
         "eg:gisco_id":"BE_34027",
         "eurostat:nuts_2021_id":"34027"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241107,
     "wof:geomhash":"5f19cd68bbe763fc9011f6bb605371f7",
@@ -163,7 +177,7 @@
         }
     ],
     "wof:id":1108830067,
-    "wof:lastmodified":1684351652,
+    "wof:lastmodified":1695878069,
     "wof:name":"Menen",
     "wof:parent_id":102049961,
     "wof:placetype":"localadmin",

--- a/data/110/883/007/1/1108830071.geojson
+++ b/data/110/883/007/1/1108830071.geojson
@@ -19,12 +19,24 @@
     "geom:latitude":51.101046,
     "geom:longitude":3.625688,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.102741,
     "lbl:longitude":3.625107,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Lovendegem"
@@ -110,10 +122,13 @@
         102049989
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "begov:niscode":"44036"
+    },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241107,
-    "wof:geomhash":"7010deadf163914ca5d5123cac5bcf02",
+    "wof:geomhash":"5d71c1a4212fe4b8450295139b02dc54",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -125,7 +140,7 @@
         }
     ],
     "wof:id":1108830071,
-    "wof:lastmodified":1566611557,
+    "wof:lastmodified":1695878060,
     "wof:name":"Lovendegem",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/007/3/1108830073.geojson
+++ b/data/110/883/007/3/1108830073.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.960636,
     "geom:longitude":2.775352,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.956739,
     "lbl:longitude":2.782001,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Lo-Reninge"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"32030",
         "eg:gisco_id":"BE_32030",
         "eurostat:nuts_2021_id":"32030"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241108,
     "wof:geomhash":"eca071ee9f70092fe3af6aa5d5be8c74",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830073,
-    "wof:lastmodified":1684351652,
+    "wof:lastmodified":1695878070,
     "wof:name":"Lo-Reninge",
     "wof:parent_id":102049987,
     "wof:placetype":"localadmin",

--- a/data/110/883/007/5/1108830075.geojson
+++ b/data/110/883/007/5/1108830075.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.899445,
     "geom:longitude":5.644409,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.906897,
     "lbl:longitude":5.645558,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Lanaken"
@@ -140,9 +152,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"73042",
         "eg:gisco_id":"BE_73042",
         "eurostat:nuts_2021_id":"73042"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241108,
     "wof:geomhash":"5c18ddb40e5e2a36bc0e160ef55f4386",
@@ -157,7 +171,7 @@
         }
     ],
     "wof:id":1108830075,
-    "wof:lastmodified":1684351652,
+    "wof:lastmodified":1695878070,
     "wof:name":"Lanaken",
     "wof:parent_id":1108782563,
     "wof:placetype":"localadmin",

--- a/data/110/883/007/7/1108830077.geojson
+++ b/data/110/883/007/7/1108830077.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.106478,
     "geom:longitude":4.881962,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.108786,
     "lbl:longitude":4.880677,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Westerlo"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13049",
         "eg:gisco_id":"BE_13049",
         "eurostat:nuts_2021_id":"13049"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241108,
     "wof:geomhash":"1753e64750a5f6e6057d06ee4573e14c",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830077,
-    "wof:lastmodified":1684351653,
+    "wof:lastmodified":1695878070,
     "wof:name":"Westerlo",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/007/9/1108830079.geojson
+++ b/data/110/883/007/9/1108830079.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.930596,
     "geom:longitude":3.337214,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.925024,
     "lbl:longitude":3.334154,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Oostrozebeke"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"37010",
         "eg:gisco_id":"BE_37010",
         "eurostat:nuts_2021_id":"37010"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241109,
     "wof:geomhash":"e8cb9ba92b0a99ba3643e35637261d30",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830079,
-    "wof:lastmodified":1684351653,
+    "wof:lastmodified":1695878071,
     "wof:name":"Oostrozebeke",
     "wof:parent_id":102049981,
     "wof:placetype":"localadmin",

--- a/data/110/883/008/1/1108830081.geojson
+++ b/data/110/883/008/1/1108830081.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.725941,
     "geom:longitude":5.425431,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.727313,
     "lbl:longitude":5.425282,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Herstappe"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"73028",
         "eg:gisco_id":"BE_73028",
         "eurostat:nuts_2021_id":"73028"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241109,
     "wof:geomhash":"cbf41ac4222fa3899f22e8c216c03ec2",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830081,
-    "wof:lastmodified":1684351653,
+    "wof:lastmodified":1695878071,
     "wof:name":"Herstappe",
     "wof:parent_id":1108782563,
     "wof:placetype":"localadmin",

--- a/data/110/883/008/3/1108830083.geojson
+++ b/data/110/883/008/3/1108830083.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.074419,
     "geom:longitude":3.725505,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.047907,
     "lbl:longitude":3.705053,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ceb_x_preferred":[
         "Gent"
@@ -77,9 +89,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"44021",
         "eg:gisco_id":"BE_44021",
         "eurostat:nuts_2021_id":"44021"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241109,
     "wof:geomhash":"776d4d520dd777a7bd071cc3f3ac3a07",
@@ -94,7 +108,7 @@
         }
     ],
     "wof:id":1108830083,
-    "wof:lastmodified":1684351653,
+    "wof:lastmodified":1695878071,
     "wof:name":"Gent",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/008/5/1108830085.geojson
+++ b/data/110/883/008/5/1108830085.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.930245,
     "geom:longitude":4.433887,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.933412,
     "lbl:longitude":4.43914,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Vilvoorde"
@@ -158,9 +170,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23088",
         "eg:gisco_id":"BE_23088",
         "eurostat:nuts_2021_id":"23088"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241110,
     "wof:geomhash":"09c56b4b051b065560f5084275149725",
@@ -175,7 +189,7 @@
         }
     ],
     "wof:id":1108830085,
-    "wof:lastmodified":1684351653,
+    "wof:lastmodified":1695878071,
     "wof:name":"Vilvoorde",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/008/9/1108830089.geojson
+++ b/data/110/883/008/9/1108830089.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.951052,
     "geom:longitude":3.295029,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.947564,
     "lbl:longitude":3.301119,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Meulebeke"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"37007",
         "eg:gisco_id":"BE_37007",
         "eurostat:nuts_2021_id":"37007"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241110,
     "wof:geomhash":"ebdd838f141da16a36d0f10d57003092",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830089,
-    "wof:lastmodified":1684351653,
+    "wof:lastmodified":1695878072,
     "wof:name":"Meulebeke",
     "wof:parent_id":102049981,
     "wof:placetype":"localadmin",

--- a/data/110/883/009/1/1108830091.geojson
+++ b/data/110/883/009/1/1108830091.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.260011,
     "geom:longitude":3.58023,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.256845,
     "lbl:longitude":3.564267,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0633\u064a\u0646\u062a- \u0644\u0627\u0648\u0631\u0627\u064a\u0646\u0632"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"43014",
         "eg:gisco_id":"BE_43014",
         "eurostat:nuts_2021_id":"43014"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241110,
     "wof:geomhash":"08bffbfba101965757682dbf8f63352e",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830091,
-    "wof:lastmodified":1684351653,
+    "wof:lastmodified":1695878072,
     "wof:name":"Sint-Laureins",
     "wof:parent_id":102049995,
     "wof:placetype":"localadmin",

--- a/data/110/883/009/3/1108830093.geojson
+++ b/data/110/883/009/3/1108830093.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.996975,
     "geom:longitude":3.796296,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.992576,
     "lbl:longitude":3.793796,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bel_x_preferred":[
         "\u041c\u0435\u043b\u0435"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"44040",
         "eg:gisco_id":"BE_44040",
         "eurostat:nuts_2021_id":"44040"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241110,
     "wof:geomhash":"6f97eec9ebbde40ebafff72b566ec549",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830093,
-    "wof:lastmodified":1684351653,
+    "wof:lastmodified":1695878072,
     "wof:name":"Melle",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/009/5/1108830095.geojson
+++ b/data/110/883/009/5/1108830095.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.78695,
     "geom:longitude":3.372564,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.78009,
     "lbl:longitude":3.36505,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Zwevegem"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"34042",
         "eg:gisco_id":"BE_34042",
         "eurostat:nuts_2021_id":"34042"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241111,
     "wof:geomhash":"287f56610edd77cfe2d3bb389ceb0dd5",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830095,
-    "wof:lastmodified":1684351653,
+    "wof:lastmodified":1695878072,
     "wof:name":"Zwevegem",
     "wof:parent_id":102049961,
     "wof:placetype":"localadmin",

--- a/data/110/883/009/7/1108830097.geojson
+++ b/data/110/883/009/7/1108830097.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.118366,
     "geom:longitude":4.573897,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.124851,
     "lbl:longitude":4.580628,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ceb_x_preferred":[
         "Lier"
@@ -104,9 +116,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"12021",
         "eg:gisco_id":"BE_12021",
         "eurostat:nuts_2021_id":"12021"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241111,
     "wof:geomhash":"c3afcc8e13427532469b70da01358071",
@@ -121,7 +135,7 @@
         }
     ],
     "wof:id":1108830097,
-    "wof:lastmodified":1684351654,
+    "wof:lastmodified":1695878073,
     "wof:name":"Lier",
     "wof:parent_id":102049985,
     "wof:placetype":"localadmin",

--- a/data/110/883/009/9/1108830099.geojson
+++ b/data/110/883/009/9/1108830099.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.863823,
     "geom:longitude":3.30736,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.884991,
     "lbl:longitude":3.294365,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0647\u0627\u0631\u064a\u0644 \u0628\u064a\u0643"
@@ -152,9 +164,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"34013",
         "eg:gisco_id":"BE_34013",
         "eurostat:nuts_2021_id":"34013"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241112,
     "wof:geomhash":"0c75c47a7eac2cafda63848ef50fe027",
@@ -169,7 +183,7 @@
         }
     ],
     "wof:id":1108830099,
-    "wof:lastmodified":1684351654,
+    "wof:lastmodified":1695878073,
     "wof:name":"Harelbeke",
     "wof:parent_id":102049961,
     "wof:placetype":"localadmin",

--- a/data/110/883/010/1/1108830101.geojson
+++ b/data/110/883/010/1/1108830101.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.866473,
     "geom:longitude":3.003632,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.860528,
     "lbl:longitude":3.002642,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Zonnebeke"
@@ -164,9 +176,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"33037",
         "eg:gisco_id":"BE_33037",
         "eurostat:nuts_2021_id":"33037"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241112,
     "wof:geomhash":"29be5adb75451fdddee3357b1f9affa2",
@@ -181,7 +195,7 @@
         }
     ],
     "wof:id":1108830101,
-    "wof:lastmodified":1684351654,
+    "wof:lastmodified":1695878073,
     "wof:name":"Zonnebeke",
     "wof:parent_id":102049971,
     "wof:placetype":"localadmin",

--- a/data/110/883/010/3/1108830103.geojson
+++ b/data/110/883/010/3/1108830103.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.805362,
     "geom:longitude":5.592331,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.807332,
     "lbl:longitude":5.593652,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Riemst"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"73066",
         "eg:gisco_id":"BE_73066",
         "eurostat:nuts_2021_id":"73066"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241112,
     "wof:geomhash":"93f77b8402104948c1eeeb8b79728ee8",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830103,
-    "wof:lastmodified":1684351654,
+    "wof:lastmodified":1695878074,
     "wof:name":"Riemst",
     "wof:parent_id":1108782563,
     "wof:placetype":"localadmin",

--- a/data/110/883/010/7/1108830107.geojson
+++ b/data/110/883/010/7/1108830107.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.011841,
     "geom:longitude":4.19903,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.006913,
     "lbl:longitude":4.194699,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Buggenhout"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"42004",
         "eg:gisco_id":"BE_42004",
         "eurostat:nuts_2021_id":"42004"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241113,
     "wof:geomhash":"f7d4a075e804d6bd9f5fd7a496854cfd",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830107,
-    "wof:lastmodified":1684351654,
+    "wof:lastmodified":1695878074,
     "wof:name":"Buggenhout",
     "wof:parent_id":102049979,
     "wof:placetype":"localadmin",

--- a/data/110/883/010/9/1108830109.geojson
+++ b/data/110/883/010/9/1108830109.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.904171,
     "geom:longitude":4.115706,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.903905,
     "lbl:longitude":4.122592,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Affligem"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23105",
         "eg:gisco_id":"BE_23105",
         "eurostat:nuts_2021_id":"23105"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241113,
     "wof:geomhash":"567e46eb2f80f400c4599c0384f07108",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830109,
-    "wof:lastmodified":1684351654,
+    "wof:lastmodified":1695878074,
     "wof:name":"Affligem",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/011/1/1108830111.geojson
+++ b/data/110/883/011/1/1108830111.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.192804,
     "geom:longitude":4.59063,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.191965,
     "lbl:longitude":4.591489,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Ranst"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11035",
         "eg:gisco_id":"BE_11035",
         "eurostat:nuts_2021_id":"11035"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241113,
     "wof:geomhash":"e29a3bb3017cfa8d2cd8ef0db5aa6df8",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830111,
-    "wof:lastmodified":1684351654,
+    "wof:lastmodified":1695878074,
     "wof:name":"Ranst",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/011/3/1108830113.geojson
+++ b/data/110/883/011/3/1108830113.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.255746,
     "geom:longitude":4.834204,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.250465,
     "lbl:longitude":4.829265,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Lille"
@@ -395,9 +407,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13019",
         "eg:gisco_id":"BE_13019",
         "eurostat:nuts_2021_id":"13019"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241114,
     "wof:geomhash":"a824b4ba6ef513e8406b20bb32f3e7c9",
@@ -412,7 +426,7 @@
         }
     ],
     "wof:id":1108830113,
-    "wof:lastmodified":1684351655,
+    "wof:lastmodified":1695878075,
     "wof:name":"Lille",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/011/5/1108830115.geojson
+++ b/data/110/883/011/5/1108830115.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.974357,
     "geom:longitude":3.74074,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.97338,
     "lbl:longitude":3.739926,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Merelbeke"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"44043",
         "eg:gisco_id":"BE_44043",
         "eurostat:nuts_2021_id":"44043"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241114,
     "wof:geomhash":"1b2689cffa0d607ac1efc2cecc9f60c6",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830115,
-    "wof:lastmodified":1684351655,
+    "wof:lastmodified":1695878075,
     "wof:name":"Merelbeke",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/011/7/1108830117.geojson
+++ b/data/110/883/011/7/1108830117.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.260161,
     "geom:longitude":5.507296,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.271327,
     "lbl:longitude":5.498058,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Hamont-Achel"
@@ -146,9 +158,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"72037",
         "eg:gisco_id":"BE_72037",
         "eurostat:nuts_2021_id":"72037"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241114,
     "wof:geomhash":"f85e07cca0b58264245a374b9f71fe9a",
@@ -163,7 +177,7 @@
         }
     ],
     "wof:id":1108830117,
-    "wof:lastmodified":1684351655,
+    "wof:lastmodified":1695878075,
     "wof:name":"Hamont-Achel",
     "wof:parent_id":102049993,
     "wof:placetype":"localadmin",

--- a/data/110/883/011/9/1108830119.geojson
+++ b/data/110/883/011/9/1108830119.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.86783,
     "geom:longitude":4.160216,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.86513,
     "lbl:longitude":4.169306,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Ternat"
@@ -119,9 +131,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23086",
         "eg:gisco_id":"BE_23086",
         "eurostat:nuts_2021_id":"23086"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241115,
     "wof:geomhash":"52b3422a0539a1dca441d35cbe8d6edc",
@@ -136,7 +150,7 @@
         }
     ],
     "wof:id":1108830119,
-    "wof:lastmodified":1684351655,
+    "wof:lastmodified":1695878075,
     "wof:name":"Ternat",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/012/1/1108830121.geojson
+++ b/data/110/883/012/1/1108830121.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.931017,
     "geom:longitude":3.87585,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.932302,
     "lbl:longitude":3.869085,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bar_x_preferred":[
         "Sint-Lievens-Houtem"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"41063",
         "eg:gisco_id":"BE_41063",
         "eurostat:nuts_2021_id":"41063"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241115,
     "wof:geomhash":"5211f54aab848a0e17fd26da21afde8f",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830121,
-    "wof:lastmodified":1684351655,
+    "wof:lastmodified":1695878076,
     "wof:name":"Sint-Lievens-Houtem",
     "wof:parent_id":102049967,
     "wof:placetype":"localadmin",

--- a/data/110/883/012/5/1108830125.geojson
+++ b/data/110/883/012/5/1108830125.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.88218,
     "geom:longitude":4.705918,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.874831,
     "lbl:longitude":4.711317,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Leuven"
@@ -242,9 +254,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24062",
         "eg:gisco_id":"BE_24062",
         "eurostat:nuts_2021_id":"24062"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241115,
     "wof:geomhash":"30a46bcf4f51f66ce9904529ce81ba7b",
@@ -259,7 +273,7 @@
         }
     ],
     "wof:id":1108830125,
-    "wof:lastmodified":1684351655,
+    "wof:lastmodified":1695878076,
     "wof:name":"Leuven",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/012/7/1108830127.geojson
+++ b/data/110/883/012/7/1108830127.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.831322,
     "geom:longitude":3.174016,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.830237,
     "lbl:longitude":3.174939,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0648\u0641\u0644\u062c\u0645"
@@ -149,9 +161,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"34041",
         "eg:gisco_id":"BE_34041",
         "eurostat:nuts_2021_id":"34041"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241115,
     "wof:geomhash":"3bb77b0e2eaefb861abc4e8748c6316e",
@@ -166,7 +180,7 @@
         }
     ],
     "wof:id":1108830127,
-    "wof:lastmodified":1684351655,
+    "wof:lastmodified":1695878076,
     "wof:name":"Wevelgem",
     "wof:parent_id":102049961,
     "wof:placetype":"localadmin",

--- a/data/110/883/012/9/1108830129.geojson
+++ b/data/110/883/012/9/1108830129.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.779681,
     "geom:longitude":3.530096,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.787472,
     "lbl:longitude":3.536405,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Kluisbergen"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"45060",
         "eg:gisco_id":"BE_45060",
         "eurostat:nuts_2021_id":"45060"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241116,
     "wof:geomhash":"69c7813b1bbb3cb9f0e3d0a5a5925594",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830129,
-    "wof:lastmodified":1684351655,
+    "wof:lastmodified":1695878077,
     "wof:name":"Kluisbergen",
     "wof:parent_id":102049963,
     "wof:placetype":"localadmin",

--- a/data/110/883/013/1/1108830131.geojson
+++ b/data/110/883/013/1/1108830131.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.934349,
     "geom:longitude":4.977856,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.939515,
     "lbl:longitude":4.971661,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bar_x_preferred":[
         "Bekkevoort"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24008",
         "eg:gisco_id":"BE_24008",
         "eurostat:nuts_2021_id":"24008"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241116,
     "wof:geomhash":"d8724a9041d3adb5c0c58675d00dde6c",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830131,
-    "wof:lastmodified":1684351656,
+    "wof:lastmodified":1695878077,
     "wof:name":"Bekkevoort",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/013/3/1108830133.geojson
+++ b/data/110/883/013/3/1108830133.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.087844,
     "geom:longitude":5.715225,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.100878,
     "lbl:longitude":5.707519,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Maaseik"
@@ -161,9 +173,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"72021",
         "eg:gisco_id":"BE_72021",
         "eurostat:nuts_2021_id":"72021"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241117,
     "wof:geomhash":"e039adc8a6697569ce26cff8d413ac97",
@@ -178,7 +192,7 @@
         }
     ],
     "wof:id":1108830133,
-    "wof:lastmodified":1684351656,
+    "wof:lastmodified":1695878077,
     "wof:name":"Maaseik",
     "wof:parent_id":102049993,
     "wof:placetype":"localadmin",

--- a/data/110/883/013/5/1108830135.geojson
+++ b/data/110/883/013/5/1108830135.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.174645,
     "geom:longitude":4.461038,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.174157,
     "lbl:longitude":4.461046,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Mortsel"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11029",
         "eg:gisco_id":"BE_11029",
         "eurostat:nuts_2021_id":"11029"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241117,
     "wof:geomhash":"69e1e6ec48b8ace1bbd9e9bff00e989d",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830135,
-    "wof:lastmodified":1684351656,
+    "wof:lastmodified":1695878078,
     "wof:name":"Mortsel",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/013/7/1108830137.geojson
+++ b/data/110/883/013/7/1108830137.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.921023,
     "geom:longitude":4.499251,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.921186,
     "lbl:longitude":4.498676,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Steenokkerzeel"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23081",
         "eg:gisco_id":"BE_23081",
         "eurostat:nuts_2021_id":"23081"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241118,
     "wof:geomhash":"2e61cfc17ddeee28d7f0fe3acd932e94",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830137,
-    "wof:lastmodified":1684351656,
+    "wof:lastmodified":1695878078,
     "wof:name":"Steenokkerzeel",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/013/9/1108830139.geojson
+++ b/data/110/883/013/9/1108830139.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.795177,
     "geom:longitude":3.641132,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.793972,
     "lbl:longitude":3.626525,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Maarkedal"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"45064",
         "eg:gisco_id":"BE_45064",
         "eurostat:nuts_2021_id":"45064"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241118,
     "wof:geomhash":"43e639e905b6666d5cbd78d0a03dedc9",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830139,
-    "wof:lastmodified":1684351656,
+    "wof:lastmodified":1695878078,
     "wof:name":"Maarkedal",
     "wof:parent_id":102049963,
     "wof:placetype":"localadmin",

--- a/data/110/883/014/3/1108830143.geojson
+++ b/data/110/883/014/3/1108830143.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.141895,
     "geom:longitude":5.632485,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.146749,
     "lbl:longitude":5.63088,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ceb_x_preferred":[
         "Bree"
@@ -95,9 +107,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"72004",
         "eg:gisco_id":"BE_72004",
         "eurostat:nuts_2021_id":"72004"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241118,
     "wof:geomhash":"683dfbe39ae1b58445fa2abdd6a22417",
@@ -112,7 +126,7 @@
         }
     ],
     "wof:id":1108830143,
-    "wof:lastmodified":1684351656,
+    "wof:lastmodified":1695878078,
     "wof:name":"Bree",
     "wof:parent_id":102049993,
     "wof:placetype":"localadmin",

--- a/data/110/883/014/5/1108830145.geojson
+++ b/data/110/883/014/5/1108830145.geojson
@@ -19,12 +19,24 @@
     "geom:latitude":51.051138,
     "geom:longitude":4.230962,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.055577,
     "lbl:longitude":4.238977,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Sint-Amands"
@@ -110,10 +122,13 @@
         102049985
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "begov:niscode":"12034"
+    },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241119,
-    "wof:geomhash":"b7902414077c590ad911d6529d535cbb",
+    "wof:geomhash":"af084dc3ef11483070523211a24e2863",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -125,7 +140,7 @@
         }
     ],
     "wof:id":1108830145,
-    "wof:lastmodified":1566611528,
+    "wof:lastmodified":1695878059,
     "wof:name":"Sint-Amands",
     "wof:parent_id":102049985,
     "wof:placetype":"localadmin",

--- a/data/110/883/014/7/1108830147.geojson
+++ b/data/110/883/014/7/1108830147.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.233762,
     "geom:longitude":5.152832,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.284799,
     "lbl:longitude":5.194388,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bos_x_preferred":[
         "Mol"
@@ -140,9 +152,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13025",
         "eg:gisco_id":"BE_13025",
         "eurostat:nuts_2021_id":"13025"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241119,
     "wof:geomhash":"d1cf9f26b851c1836625efa05e0f0ba2",
@@ -157,7 +171,7 @@
         }
     ],
     "wof:id":1108830147,
-    "wof:lastmodified":1684351657,
+    "wof:lastmodified":1695878079,
     "wof:name":"Mol",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/014/9/1108830149.geojson
+++ b/data/110/883/014/9/1108830149.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.138445,
     "geom:longitude":5.346485,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.137399,
     "lbl:longitude":5.346489,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Hechtel-Eksel"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"72038",
         "eg:gisco_id":"BE_72038",
         "eurostat:nuts_2021_id":"72038"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241119,
     "wof:geomhash":"bd2df8dc27515488ef2e34a892b1187b",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830149,
-    "wof:lastmodified":1684351657,
+    "wof:lastmodified":1695878079,
     "wof:name":"Hechtel-Eksel",
     "wof:parent_id":102049993,
     "wof:placetype":"localadmin",

--- a/data/110/883/015/1/1108830151.geojson
+++ b/data/110/883/015/1/1108830151.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.921082,
     "geom:longitude":3.205509,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.920791,
     "lbl:longitude":3.206192,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Izegem"
@@ -143,9 +155,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"36008",
         "eg:gisco_id":"BE_36008",
         "eurostat:nuts_2021_id":"36008"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241120,
     "wof:geomhash":"655a00b35d596ff0a11b272ff8de98d7",
@@ -160,7 +174,7 @@
         }
     ],
     "wof:id":1108830151,
-    "wof:lastmodified":1684351657,
+    "wof:lastmodified":1695878080,
     "wof:name":"Izegem",
     "wof:parent_id":102049977,
     "wof:placetype":"localadmin",

--- a/data/110/883/015/3/1108830153.geojson
+++ b/data/110/883/015/3/1108830153.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.991916,
     "geom:longitude":5.376657,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.993921,
     "lbl:longitude":5.376678,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Zonhoven"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71066",
         "eg:gisco_id":"BE_71066",
         "eurostat:nuts_2021_id":"71066"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241120,
     "wof:geomhash":"c22ef1d976d6a9f6cc62ccc92729e3c9",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830153,
-    "wof:lastmodified":1684351657,
+    "wof:lastmodified":1695878080,
     "wof:name":"Zonhoven",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/015/5/1108830155.geojson
+++ b/data/110/883/015/5/1108830155.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.264164,
     "geom:longitude":4.508222,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.261108,
     "lbl:longitude":4.508226,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0634\u0648\u062a\u0627\u0646"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11040",
         "eg:gisco_id":"BE_11040",
         "eurostat:nuts_2021_id":"11040"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241120,
     "wof:geomhash":"1aa517b70ec2a88d96cf0e2a53efc30d",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830155,
-    "wof:lastmodified":1684351657,
+    "wof:lastmodified":1695878080,
     "wof:name":"Schoten",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/015/7/1108830157.geojson
+++ b/data/110/883/015/7/1108830157.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.188635,
     "geom:longitude":3.09636,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.180132,
     "lbl:longitude":3.095211,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Jabbeke"
@@ -143,9 +155,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"31012",
         "eg:gisco_id":"BE_31012",
         "eurostat:nuts_2021_id":"31012"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241121,
     "wof:geomhash":"9b73b535b15971de05c91a632100f828",
@@ -160,7 +174,7 @@
         }
     ],
     "wof:id":1108830157,
-    "wof:lastmodified":1684351657,
+    "wof:lastmodified":1695878081,
     "wof:name":"Jabbeke",
     "wof:parent_id":102050003,
     "wof:placetype":"localadmin",

--- a/data/110/883/016/1/1108830161.geojson
+++ b/data/110/883/016/1/1108830161.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.078168,
     "geom:longitude":4.139867,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.08188,
     "lbl:longitude":4.145699,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Hamme"
@@ -140,9 +152,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"42008",
         "eg:gisco_id":"BE_42008",
         "eurostat:nuts_2021_id":"42008"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241121,
     "wof:geomhash":"dc226c3d1cd50a9546b5b63bd46ab21e",
@@ -157,7 +171,7 @@
         }
     ],
     "wof:id":1108830161,
-    "wof:lastmodified":1684351657,
+    "wof:lastmodified":1695878081,
     "wof:name":"Hamme",
     "wof:parent_id":102049979,
     "wof:placetype":"localadmin",

--- a/data/110/883/016/3/1108830163.geojson
+++ b/data/110/883/016/3/1108830163.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.08095,
     "geom:longitude":5.00598,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.076327,
     "lbl:longitude":4.984517,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Laakdal"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13053",
         "eg:gisco_id":"BE_13053",
         "eurostat:nuts_2021_id":"13053"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241122,
     "wof:geomhash":"6fbc30ad73def3577f958a2e2bc151b2",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830163,
-    "wof:lastmodified":1684351657,
+    "wof:lastmodified":1695878081,
     "wof:name":"Laakdal",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/016/5/1108830165.geojson
+++ b/data/110/883/016/5/1108830165.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.046554,
     "geom:longitude":2.66459,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.043117,
     "lbl:longitude":2.657425,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Veurne"
@@ -146,9 +158,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"38025",
         "eg:gisco_id":"BE_38025",
         "eurostat:nuts_2021_id":"38025"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241122,
     "wof:geomhash":"deebd7f8601a758afa95a682a5f30113",
@@ -163,7 +177,7 @@
         }
     ],
     "wof:id":1108830165,
-    "wof:lastmodified":1684351658,
+    "wof:lastmodified":1695878082,
     "wof:name":"Veurne",
     "wof:parent_id":102049991,
     "wof:placetype":"localadmin",

--- a/data/110/883/016/7/1108830167.geojson
+++ b/data/110/883/016/7/1108830167.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.749701,
     "geom:longitude":3.607644,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.749197,
     "lbl:longitude":3.60656,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Ronse"
@@ -149,9 +161,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"45041",
         "eg:gisco_id":"BE_45041",
         "eurostat:nuts_2021_id":"45041"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241123,
     "wof:geomhash":"337f667bd3875da75bd2282d97d4ce38",
@@ -166,7 +180,7 @@
         }
     ],
     "wof:id":1108830167,
-    "wof:lastmodified":1684351658,
+    "wof:lastmodified":1695878082,
     "wof:name":"Ronse",
     "wof:parent_id":102049963,
     "wof:placetype":"localadmin",

--- a/data/110/883/016/9/1108830169.geojson
+++ b/data/110/883/016/9/1108830169.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.225625,
     "geom:longitude":5.302083,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.215974,
     "lbl:longitude":5.292103,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Lommel"
@@ -158,9 +170,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"72020",
         "eg:gisco_id":"BE_72020",
         "eurostat:nuts_2021_id":"72020"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241123,
     "wof:geomhash":"9a366bed86361d938ab7f4807c26f50f",
@@ -175,7 +189,7 @@
         }
     ],
     "wof:id":1108830169,
-    "wof:lastmodified":1684351658,
+    "wof:lastmodified":1695878082,
     "wof:name":"Lommel",
     "wof:parent_id":102049993,
     "wof:placetype":"localadmin",

--- a/data/110/883/017/1/1108830171.geojson
+++ b/data/110/883/017/1/1108830171.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.989432,
     "geom:longitude":3.082293,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.988606,
     "lbl:longitude":3.08355,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Hooglede"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"36006",
         "eg:gisco_id":"BE_36006",
         "eurostat:nuts_2021_id":"36006"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241123,
     "wof:geomhash":"f21cff1786aa7f7d81192d1182552d2c",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830171,
-    "wof:lastmodified":1684351658,
+    "wof:lastmodified":1695878082,
     "wof:name":"Hooglede",
     "wof:parent_id":102049977,
     "wof:placetype":"localadmin",

--- a/data/110/883/017/3/1108830173.geojson
+++ b/data/110/883/017/3/1108830173.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.093826,
     "geom:longitude":4.421094,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.09315,
     "lbl:longitude":4.42193,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Rumst"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11037",
         "eg:gisco_id":"BE_11037",
         "eurostat:nuts_2021_id":"11037"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241124,
     "wof:geomhash":"edd8ab44b676acc5e342ea11977c5d6f",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830173,
-    "wof:lastmodified":1684351658,
+    "wof:lastmodified":1695878082,
     "wof:name":"Rumst",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/017/5/1108830175.geojson
+++ b/data/110/883/017/5/1108830175.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.964046,
     "geom:longitude":4.641189,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.964583,
     "lbl:longitude":4.645489,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Haacht"
@@ -119,9 +131,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24033",
         "eg:gisco_id":"BE_24033",
         "eurostat:nuts_2021_id":"24033"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241124,
     "wof:geomhash":"61b0651ef401b8ebaa1c35d0718ead9e",
@@ -136,7 +150,7 @@
         }
     ],
     "wof:id":1108830175,
-    "wof:lastmodified":1684351658,
+    "wof:lastmodified":1695878083,
     "wof:name":"Haacht",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/017/9/1108830179.geojson
+++ b/data/110/883/017/9/1108830179.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.414936,
     "geom:longitude":5.025964,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.411806,
     "lbl:longitude":5.031991,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0631\u0627\u0641\u064a\u0644\u0633"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13035",
         "eg:gisco_id":"BE_13035",
         "eurostat:nuts_2021_id":"13035"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241124,
     "wof:geomhash":"92dd5983cc4d4de3e0ac2d763f885595",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830179,
-    "wof:lastmodified":1684351658,
+    "wof:lastmodified":1695878083,
     "wof:name":"Ravels",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/018/1/1108830181.geojson
+++ b/data/110/883/018/1/1108830181.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.119347,
     "geom:longitude":3.230346,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.12131,
     "lbl:longitude":3.231509,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Oostkamp"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"31022",
         "eg:gisco_id":"BE_31022",
         "eurostat:nuts_2021_id":"31022"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241124,
     "wof:geomhash":"06a49d46f4e1708c4b2b136a072ea386",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830181,
-    "wof:lastmodified":1684351658,
+    "wof:lastmodified":1695878083,
     "wof:name":"Oostkamp",
     "wof:parent_id":102050003,
     "wof:placetype":"localadmin",

--- a/data/110/883/018/3/1108830183.geojson
+++ b/data/110/883/018/3/1108830183.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.793537,
     "geom:longitude":4.309017,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.792998,
     "lbl:longitude":4.31057,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Drogenbos"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23098",
         "eg:gisco_id":"BE_23098",
         "eurostat:nuts_2021_id":"23098"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241125,
     "wof:geomhash":"636747d047025a1203c0951a4db188c9",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830183,
-    "wof:lastmodified":1684351659,
+    "wof:lastmodified":1695878083,
     "wof:name":"Drogenbos",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/018/5/1108830185.geojson
+++ b/data/110/883/018/5/1108830185.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.256168,
     "geom:longitude":4.581479,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.254664,
     "lbl:longitude":4.577282,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Schilde"
@@ -119,9 +131,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11039",
         "eg:gisco_id":"BE_11039",
         "eurostat:nuts_2021_id":"11039"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241125,
     "wof:geomhash":"5141e6b980151a6b7dddee01e5da1b78",
@@ -136,7 +150,7 @@
         }
     ],
     "wof:id":1108830185,
-    "wof:lastmodified":1684351659,
+    "wof:lastmodified":1695878084,
     "wof:name":"Schilde",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/018/7/1108830187.geojson
+++ b/data/110/883/018/7/1108830187.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.810128,
     "geom:longitude":3.05647,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.810825,
     "lbl:longitude":3.055434,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Wervik"
@@ -143,9 +155,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"33029",
         "eg:gisco_id":"BE_33029",
         "eurostat:nuts_2021_id":"33029"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241125,
     "wof:geomhash":"2d0d4e5266575716c9010eba130eb602",
@@ -160,7 +174,7 @@
         }
     ],
     "wof:id":1108830187,
-    "wof:lastmodified":1684351659,
+    "wof:lastmodified":1695878084,
     "wof:name":"Wervik",
     "wof:parent_id":102049971,
     "wof:placetype":"localadmin",

--- a/data/110/883/018/9/1108830189.geojson
+++ b/data/110/883/018/9/1108830189.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.845365,
     "geom:longitude":4.47134,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.855488,
     "lbl:longitude":4.469186,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Kraainem"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23099",
         "eg:gisco_id":"BE_23099",
         "eurostat:nuts_2021_id":"23099"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241125,
     "wof:geomhash":"09b175e6bd0db0947014ab40875991b8",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830189,
-    "wof:lastmodified":1684351659,
+    "wof:lastmodified":1695878084,
     "wof:name":"Kraainem",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/019/1/1108830191.geojson
+++ b/data/110/883/019/1/1108830191.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.93884,
     "geom:longitude":3.797148,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.938531,
     "lbl:longitude":3.796212,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Oosterzele"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"44052",
         "eg:gisco_id":"BE_44052",
         "eurostat:nuts_2021_id":"44052"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241126,
     "wof:geomhash":"c34487e07cb81529a14c8b95261cadf6",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830191,
-    "wof:lastmodified":1684351659,
+    "wof:lastmodified":1695878084,
     "wof:name":"Oosterzele",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/019/3/1108830193.geojson
+++ b/data/110/883/019/3/1108830193.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.229577,
     "geom:longitude":4.118897,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.234389,
     "lbl:longitude":4.122569,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Sint-Gillis-Waas"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"46020",
         "eg:gisco_id":"BE_46020",
         "eurostat:nuts_2021_id":"46020"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241126,
     "wof:geomhash":"35b82a9f01fc43d7e8f9c83fa8f630b2",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830193,
-    "wof:lastmodified":1684351659,
+    "wof:lastmodified":1695878085,
     "wof:name":"Sint-Gillis-Waas",
     "wof:parent_id":102049997,
     "wof:placetype":"localadmin",

--- a/data/110/883/019/7/1108830197.geojson
+++ b/data/110/883/019/7/1108830197.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.95322,
     "geom:longitude":3.406579,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.957666,
     "lbl:longitude":3.397441,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Dentergem"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"37002",
         "eg:gisco_id":"BE_37002",
         "eurostat:nuts_2021_id":"37002"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241127,
     "wof:geomhash":"a5a5be4b26fa6298ecbc7cfc1c4571fa",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830197,
-    "wof:lastmodified":1684351659,
+    "wof:lastmodified":1695878085,
     "wof:name":"Dentergem",
     "wof:parent_id":102049981,
     "wof:placetype":"localadmin",

--- a/data/110/883/019/9/1108830199.geojson
+++ b/data/110/883/019/9/1108830199.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.150898,
     "geom:longitude":4.663592,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.156181,
     "lbl:longitude":4.658629,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0646\u064a\u062c\u0644\u0646"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"12026",
         "eg:gisco_id":"BE_12026",
         "eurostat:nuts_2021_id":"12026"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241127,
     "wof:geomhash":"b9c7b97c2c6fd852897c6011f6713c4f",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830199,
-    "wof:lastmodified":1684351659,
+    "wof:lastmodified":1695878085,
     "wof:name":"Nijlen",
     "wof:parent_id":102049985,
     "wof:placetype":"localadmin",

--- a/data/110/883/020/1/1108830201.geojson
+++ b/data/110/883/020/1/1108830201.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.165676,
     "geom:longitude":4.516875,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.16422,
     "lbl:longitude":4.505607,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Boechout"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11004",
         "eg:gisco_id":"BE_11004",
         "eurostat:nuts_2021_id":"11004"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241128,
     "wof:geomhash":"649e8043e060cc05f2566d5f8298329e",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830201,
-    "wof:lastmodified":1684351659,
+    "wof:lastmodified":1695878085,
     "wof:name":"Boechout",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/020/3/1108830203.geojson
+++ b/data/110/883/020/3/1108830203.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.191458,
     "geom:longitude":4.487687,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.191156,
     "lbl:longitude":4.487393,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Borsbeek"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11007",
         "eg:gisco_id":"BE_11007",
         "eurostat:nuts_2021_id":"11007"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241128,
     "wof:geomhash":"1db95e810e83d8d5a268ba135c382020",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830203,
-    "wof:lastmodified":1684351660,
+    "wof:lastmodified":1695878085,
     "wof:name":"Borsbeek",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/020/5/1108830205.geojson
+++ b/data/110/883/020/5/1108830205.geojson
@@ -14,17 +14,29 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005518,
-    "geom:area_square_m":42730885.542208,
+    "geom:area_square_m":42730885.542212,
     "geom:bbox":"5.39948084779,51.1820342666,5.52905682389,51.2764322748",
     "geom:latitude":51.228875,
     "geom:longitude":5.459444,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.213617,
     "lbl:longitude":5.465777,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Neerpelt"
@@ -119,10 +131,13 @@
         102049993
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "begov:niscode":"72025"
+    },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241128,
-    "wof:geomhash":"0b0a1e049f9e3bf8e2d9c9516db9361d",
+    "wof:geomhash":"1bb043313bb553aacce508b1774d925e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -134,7 +149,7 @@
         }
     ],
     "wof:id":1108830205,
-    "wof:lastmodified":1566611602,
+    "wof:lastmodified":1695878060,
     "wof:name":"Neerpelt",
     "wof:parent_id":102049993,
     "wof:placetype":"localadmin",

--- a/data/110/883/020/7/1108830207.geojson
+++ b/data/110/883/020/7/1108830207.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.853297,
     "geom:longitude":4.233841,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.855267,
     "lbl:longitude":4.229648,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Dilbeek"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23016",
         "eg:gisco_id":"BE_23016",
         "eurostat:nuts_2021_id":"23016"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241128,
     "wof:geomhash":"28abcbb917547300b95c570321c9a2d8",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830207,
-    "wof:lastmodified":1684351660,
+    "wof:lastmodified":1695878086,
     "wof:name":"Dilbeek",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/020/9/1108830209.geojson
+++ b/data/110/883/020/9/1108830209.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.123705,
     "geom:longitude":4.44459,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.125766,
     "lbl:longitude":4.443745,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Kontich"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11024",
         "eg:gisco_id":"BE_11024",
         "eurostat:nuts_2021_id":"11024"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241129,
     "wof:geomhash":"5b0b3ed7f2d5e00ee47432fe2bd56623",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830209,
-    "wof:lastmodified":1684351660,
+    "wof:lastmodified":1695878086,
     "wof:name":"Kontich",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/021/1/1108830211.geojson
+++ b/data/110/883/021/1/1108830211.geojson
@@ -14,17 +14,29 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011714,
-    "geom:area_square_m":90990799.302846,
+    "geom:area_square_m":90990799.302843,
     "geom:bbox":"5.45438407266,51.0294779015,5.66606660486,51.1463475274",
     "geom:latitude":51.084407,
     "geom:longitude":5.552194,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.09262,
     "lbl:longitude":5.532931,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Meeuwen-Gruitrode"
@@ -119,10 +131,13 @@
         102049993
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "begov:niscode":"72040"
+    },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241129,
-    "wof:geomhash":"ca393f3b26ce4a3b5edc7c8cd16d5b50",
+    "wof:geomhash":"f84f6c4bd7a7d12f1339240e1e9226b7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -134,7 +149,7 @@
         }
     ],
     "wof:id":1108830211,
-    "wof:lastmodified":1566611634,
+    "wof:lastmodified":1695878061,
     "wof:name":"Meeuwen-Gruitrode",
     "wof:parent_id":102049993,
     "wof:placetype":"localadmin",

--- a/data/110/883/021/5/1108830215.geojson
+++ b/data/110/883/021/5/1108830215.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.921517,
     "geom:longitude":3.95197,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.922183,
     "lbl:longitude":3.952846,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Erpe-Mere"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"41082",
         "eg:gisco_id":"BE_41082",
         "eurostat:nuts_2021_id":"41082"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241130,
     "wof:geomhash":"2a87fe00f5ea8c5d8f3a7d33715295ef",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830215,
-    "wof:lastmodified":1684351660,
+    "wof:lastmodified":1695878086,
     "wof:name":"Erpe-Mere",
     "wof:parent_id":102049967,
     "wof:placetype":"localadmin",

--- a/data/110/883/021/7/1108830217.geojson
+++ b/data/110/883/021/7/1108830217.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.153003,
     "geom:longitude":5.760232,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.158373,
     "lbl:longitude":5.743793,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Kinrooi"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"72018",
         "eg:gisco_id":"BE_72018",
         "eurostat:nuts_2021_id":"72018"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241130,
     "wof:geomhash":"7fe7817bcc23f595c030ce43b2067177",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830217,
-    "wof:lastmodified":1684351660,
+    "wof:lastmodified":1695878086,
     "wof:name":"Kinrooi",
     "wof:parent_id":102049993,
     "wof:placetype":"localadmin",

--- a/data/110/883/022/1/1108830221.geojson
+++ b/data/110/883/022/1/1108830221.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.257565,
     "geom:longitude":4.669803,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.259773,
     "lbl:longitude":4.670821,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Zoersel"
@@ -119,9 +131,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11055",
         "eg:gisco_id":"BE_11055",
         "eurostat:nuts_2021_id":"11055"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241130,
     "wof:geomhash":"50c6423aa5e96d1f451a0ae40d07db5a",
@@ -136,7 +150,7 @@
         }
     ],
     "wof:id":1108830221,
-    "wof:lastmodified":1684351660,
+    "wof:lastmodified":1695878087,
     "wof:name":"Zoersel",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/022/3/1108830223.geojson
+++ b/data/110/883/022/3/1108830223.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.810342,
     "geom:longitude":5.202983,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.811656,
     "lbl:longitude":5.201261,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ace_x_preferred":[
         "Sint-Truiden"
@@ -308,9 +320,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71053",
         "eg:gisco_id":"BE_71053",
         "eurostat:nuts_2021_id":"71053"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241131,
     "wof:geomhash":"838091cd100943965971f9c8b3507bdc",
@@ -325,7 +339,7 @@
         }
     ],
     "wof:id":1108830223,
-    "wof:lastmodified":1684351660,
+    "wof:lastmodified":1695878087,
     "wof:name":"Sint-Truiden",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/022/5/1108830225.geojson
+++ b/data/110/883/022/5/1108830225.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.267128,
     "geom:longitude":5.076813,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.272592,
     "lbl:longitude":5.075738,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Retie"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13036",
         "eg:gisco_id":"BE_13036",
         "eurostat:nuts_2021_id":"13036"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241131,
     "wof:geomhash":"a7a57846dfba1216ca25affb7664fce3",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830225,
-    "wof:lastmodified":1684351661,
+    "wof:lastmodified":1695878087,
     "wof:name":"Retie",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/022/7/1108830227.geojson
+++ b/data/110/883/022/7/1108830227.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.889927,
     "geom:longitude":4.568793,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.886584,
     "lbl:longitude":4.568795,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Kortenberg"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24055",
         "eg:gisco_id":"BE_24055",
         "eurostat:nuts_2021_id":"24055"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241131,
     "wof:geomhash":"dc193d5d8bb277a6911037ef9229c251",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830227,
-    "wof:lastmodified":1684351661,
+    "wof:lastmodified":1695878088,
     "wof:name":"Kortenberg",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/022/9/1108830229.geojson
+++ b/data/110/883/022/9/1108830229.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.067359,
     "geom:longitude":4.035905,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.066691,
     "lbl:longitude":4.036828,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Zele"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"42028",
         "eg:gisco_id":"BE_42028",
         "eurostat:nuts_2021_id":"42028"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241132,
     "wof:geomhash":"295eb657c48eb3d07aa877fb1a33cd26",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830229,
-    "wof:lastmodified":1684351661,
+    "wof:lastmodified":1695878088,
     "wof:name":"Zele",
     "wof:parent_id":102049979,
     "wof:placetype":"localadmin",

--- a/data/110/883/023/3/1108830233.geojson
+++ b/data/110/883/023/3/1108830233.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.107149,
     "geom:longitude":4.656143,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.107171,
     "lbl:longitude":4.656152,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Berlaar"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"12002",
         "eg:gisco_id":"BE_12002",
         "eurostat:nuts_2021_id":"12002"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241132,
     "wof:geomhash":"967a9d24607a715f650dd317b1258576",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830233,
-    "wof:lastmodified":1684351661,
+    "wof:lastmodified":1695878088,
     "wof:name":"Berlaar",
     "wof:parent_id":102049985,
     "wof:placetype":"localadmin",

--- a/data/110/883/023/5/1108830235.geojson
+++ b/data/110/883/023/5/1108830235.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.045336,
     "geom:longitude":5.408415,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.048741,
     "lbl:longitude":5.399222,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Houthalen-Helchteren"
@@ -140,9 +152,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"72039",
         "eg:gisco_id":"BE_72039",
         "eurostat:nuts_2021_id":"72039"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241133,
     "wof:geomhash":"0af137b34fec187151f3a315a7952d0d",
@@ -157,7 +171,7 @@
         }
     ],
     "wof:id":1108830235,
-    "wof:lastmodified":1684351661,
+    "wof:lastmodified":1695878089,
     "wof:name":"Houthalen-Helchteren",
     "wof:parent_id":102049993,
     "wof:placetype":"localadmin",

--- a/data/110/883/023/7/1108830237.geojson
+++ b/data/110/883/023/7/1108830237.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.217662,
     "geom:longitude":4.7729,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.220385,
     "lbl:longitude":4.773718,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Vorselaar"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13044",
         "eg:gisco_id":"BE_13044",
         "eurostat:nuts_2021_id":"13044"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241133,
     "wof:geomhash":"0735c4ff7f3ad4e1a8c7aa3c451a9767",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830237,
-    "wof:lastmodified":1684351661,
+    "wof:lastmodified":1695878089,
     "wof:name":"Vorselaar",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/023/9/1108830239.geojson
+++ b/data/110/883/023/9/1108830239.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.885996,
     "geom:longitude":3.232023,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.884957,
     "lbl:longitude":3.232813,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Lendelede"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"34025",
         "eg:gisco_id":"BE_34025",
         "eurostat:nuts_2021_id":"34025"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241133,
     "wof:geomhash":"92ca5fda5f5e07f6713b5ba44e787fb5",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830239,
-    "wof:lastmodified":1684351661,
+    "wof:lastmodified":1695878089,
     "wof:name":"Lendelede",
     "wof:parent_id":102049961,
     "wof:placetype":"localadmin",

--- a/data/110/883/024/1/1108830241.geojson
+++ b/data/110/883/024/1/1108830241.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.8431,
     "geom:longitude":4.492414,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.844132,
     "lbl:longitude":4.49277,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Wezembeek-Oppem"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23103",
         "eg:gisco_id":"BE_23103",
         "eurostat:nuts_2021_id":"23103"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241133,
     "wof:geomhash":"892d679be9f56b868592df071933de72",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830241,
-    "wof:lastmodified":1684351661,
+    "wof:lastmodified":1695878089,
     "wof:name":"Wezembeek-Oppem",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/024/3/1108830243.geojson
+++ b/data/110/883/024/3/1108830243.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.333961,
     "geom:longitude":4.443774,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.332366,
     "lbl:longitude":4.437534,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ceb_x_preferred":[
         "Kapellen"
@@ -83,9 +95,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11023",
         "eg:gisco_id":"BE_11023",
         "eurostat:nuts_2021_id":"11023"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241134,
     "wof:geomhash":"31b64d3d017545e768fc6b5840b982d4",
@@ -100,7 +114,7 @@
         }
     ],
     "wof:id":1108830243,
-    "wof:lastmodified":1684351661,
+    "wof:lastmodified":1695878089,
     "wof:name":"Kapellen",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/024/5/1108830245.geojson
+++ b/data/110/883/024/5/1108830245.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.872101,
     "geom:longitude":5.533639,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.867406,
     "lbl:longitude":5.535029,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Bilzen"
@@ -155,9 +167,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"73006",
         "eg:gisco_id":"BE_73006",
         "eurostat:nuts_2021_id":"73006"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241134,
     "wof:geomhash":"8bfaee5464a777685556d415b48294fa",
@@ -172,7 +186,7 @@
         }
     ],
     "wof:id":1108830245,
-    "wof:lastmodified":1684351661,
+    "wof:lastmodified":1695878090,
     "wof:name":"Bilzen",
     "wof:parent_id":1108782563,
     "wof:placetype":"localadmin",

--- a/data/110/883/024/7/1108830247.geojson
+++ b/data/110/883/024/7/1108830247.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.962478,
     "geom:longitude":4.180778,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.966664,
     "lbl:longitude":4.173306,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Opwijk"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23060",
         "eg:gisco_id":"BE_23060",
         "eurostat:nuts_2021_id":"23060"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241134,
     "wof:geomhash":"9e17bbf8d17750361d99af07f622d60b",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830247,
-    "wof:lastmodified":1684351662,
+    "wof:lastmodified":1695878090,
     "wof:name":"Opwijk",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/025/1/1108830251.geojson
+++ b/data/110/883/025/1/1108830251.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.910606,
     "geom:longitude":4.646562,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.903402,
     "lbl:longitude":4.657913,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Herent"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24038",
         "eg:gisco_id":"BE_24038",
         "eurostat:nuts_2021_id":"24038"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241134,
     "wof:geomhash":"c6fb2662ae5fce1b5a8414dc3df68678",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830251,
-    "wof:lastmodified":1684351662,
+    "wof:lastmodified":1695878090,
     "wof:name":"Herent",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/025/3/1108830253.geojson
+++ b/data/110/883/025/3/1108830253.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.750392,
     "geom:longitude":4.301844,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.748663,
     "lbl:longitude":4.301833,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Beersel"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23003",
         "eg:gisco_id":"BE_23003",
         "eurostat:nuts_2021_id":"23003"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241135,
     "wof:geomhash":"6abb4e53afa8f50ccc3e4cd9e2bdf2bb",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830253,
-    "wof:lastmodified":1684351662,
+    "wof:lastmodified":1695878091,
     "wof:name":"Beersel",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/025/5/1108830255.geojson
+++ b/data/110/883/025/5/1108830255.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.995306,
     "geom:longitude":5.183287,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.00019,
     "lbl:longitude":5.201241,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Lummen"
@@ -140,9 +152,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71037",
         "eg:gisco_id":"BE_71037",
         "eurostat:nuts_2021_id":"71037"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241135,
     "wof:geomhash":"0c8175316bea0cfb75f7c40bca8bf21c",
@@ -157,7 +171,7 @@
         }
     ],
     "wof:id":1108830255,
-    "wof:lastmodified":1684351662,
+    "wof:lastmodified":1695878091,
     "wof:name":"Lummen",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/025/7/1108830257.geojson
+++ b/data/110/883/025/7/1108830257.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.911482,
     "geom:longitude":5.417422,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.911041,
     "lbl:longitude":5.417417,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Diepenbeek"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71011",
         "eg:gisco_id":"BE_71011",
         "eurostat:nuts_2021_id":"71011"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241135,
     "wof:geomhash":"41c8be1598c316dcb0bb619204993dc9",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830257,
-    "wof:lastmodified":1684351662,
+    "wof:lastmodified":1695878091,
     "wof:name":"Diepenbeek",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/025/9/1108830259.geojson
+++ b/data/110/883/025/9/1108830259.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.754687,
     "geom:longitude":5.061629,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.753654,
     "lbl:longitude":5.072067,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Landen"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24059",
         "eg:gisco_id":"BE_24059",
         "eurostat:nuts_2021_id":"24059"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241136,
     "wof:geomhash":"b8f3cd05855a9e641a9e8ed0e73a79c2",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830259,
-    "wof:lastmodified":1684351663,
+    "wof:lastmodified":1695878092,
     "wof:name":"Landen",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/026/1/1108830261.geojson
+++ b/data/110/883/026/1/1108830261.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.837515,
     "geom:longitude":4.097382,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.835027,
     "lbl:longitude":4.089071,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Roosdaal"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23097",
         "eg:gisco_id":"BE_23097",
         "eurostat:nuts_2021_id":"23097"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241136,
     "wof:geomhash":"5badaa7b8e8fe2fdea74e53b5d627bd8",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830261,
-    "wof:lastmodified":1684351663,
+    "wof:lastmodified":1695878092,
     "wof:name":"Roosdaal",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/026/3/1108830263.geojson
+++ b/data/110/883/026/3/1108830263.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.91593,
     "geom:longitude":2.929386,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.916577,
     "lbl:longitude":2.93658,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Langemark-Poelkapelle"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"33040",
         "eg:gisco_id":"BE_33040",
         "eurostat:nuts_2021_id":"33040"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241137,
     "wof:geomhash":"4da0dcfdd4ffc13fbb8d93d4185218ba",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830263,
-    "wof:lastmodified":1684351663,
+    "wof:lastmodified":1695878092,
     "wof:name":"Langemark-Poelkapelle",
     "wof:parent_id":102049971,
     "wof:placetype":"localadmin",

--- a/data/110/883/026/5/1108830265.geojson
+++ b/data/110/883/026/5/1108830265.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.006471,
     "geom:longitude":3.363791,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.00259,
     "lbl:longitude":3.344303,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Tielt"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"37015",
         "eg:gisco_id":"BE_37015",
         "eurostat:nuts_2021_id":"37015"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241137,
     "wof:geomhash":"1416510f3df10eb0606b794784dde160",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830265,
-    "wof:lastmodified":1684351663,
+    "wof:lastmodified":1695878093,
     "wof:name":"Tielt",
     "wof:parent_id":102049981,
     "wof:placetype":"localadmin",

--- a/data/110/883/026/9/1108830269.geojson
+++ b/data/110/883/026/9/1108830269.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.949993,
     "geom:longitude":5.094284,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.940497,
     "lbl:longitude":5.093544,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Halen"
@@ -140,9 +152,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71020",
         "eg:gisco_id":"BE_71020",
         "eurostat:nuts_2021_id":"71020"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241137,
     "wof:geomhash":"0fefa13b9f705389a284dad60264889b",
@@ -157,7 +171,7 @@
         }
     ],
     "wof:id":1108830269,
-    "wof:lastmodified":1684351663,
+    "wof:lastmodified":1695878093,
     "wof:name":"Halen",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/027/1/1108830271.geojson
+++ b/data/110/883/027/1/1108830271.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.22716,
     "geom:longitude":3.714875,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.233734,
     "lbl:longitude":3.714881,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0623\u0633\u064a\u0646\u064a\u062f\u0647"
@@ -143,9 +155,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"43002",
         "eg:gisco_id":"BE_43002",
         "eurostat:nuts_2021_id":"43002"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241138,
     "wof:geomhash":"ab8831137eb0c71c17b909149ef6acb8",
@@ -160,7 +174,7 @@
         }
     ],
     "wof:id":1108830271,
-    "wof:lastmodified":1684351663,
+    "wof:lastmodified":1695878093,
     "wof:name":"Assenede",
     "wof:parent_id":102049995,
     "wof:placetype":"localadmin",

--- a/data/110/883/027/3/1108830273.geojson
+++ b/data/110/883/027/3/1108830273.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.921462,
     "geom:longitude":3.260681,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.917472,
     "lbl:longitude":3.263423,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Ingelmunster"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"36007",
         "eg:gisco_id":"BE_36007",
         "eurostat:nuts_2021_id":"36007"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241138,
     "wof:geomhash":"2e0da87f095e09e078c32821578b10c4",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830273,
-    "wof:lastmodified":1684351663,
+    "wof:lastmodified":1695878093,
     "wof:name":"Ingelmunster",
     "wof:parent_id":102049977,
     "wof:placetype":"localadmin",

--- a/data/110/883/027/5/1108830275.geojson
+++ b/data/110/883/027/5/1108830275.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.753669,
     "geom:longitude":5.311887,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.756533,
     "lbl:longitude":5.311874,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Heers"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"73022",
         "eg:gisco_id":"BE_73022",
         "eurostat:nuts_2021_id":"73022"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241138,
     "wof:geomhash":"4b7dbcfb9d285eaa5c0ce73f5d31522a",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830275,
-    "wof:lastmodified":1684351663,
+    "wof:lastmodified":1695878094,
     "wof:name":"Heers",
     "wof:parent_id":1108782563,
     "wof:placetype":"localadmin",

--- a/data/110/883/027/7/1108830277.geojson
+++ b/data/110/883/027/7/1108830277.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.871828,
     "geom:longitude":3.149238,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.869351,
     "lbl:longitude":3.136743,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Ledegem"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"36010",
         "eg:gisco_id":"BE_36010",
         "eurostat:nuts_2021_id":"36010"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241138,
     "wof:geomhash":"cf7549a54df93655feb517552772567a",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830277,
-    "wof:lastmodified":1684351664,
+    "wof:lastmodified":1695878094,
     "wof:name":"Ledegem",
     "wof:parent_id":102049977,
     "wof:placetype":"localadmin",

--- a/data/110/883/027/9/1108830279.geojson
+++ b/data/110/883/027/9/1108830279.geojson
@@ -14,17 +14,29 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00321,
-    "geom:area_square_m":24957264.161209,
+    "geom:area_square_m":24957264.161208,
     "geom:bbox":"5.51845617451,51.0187670424,5.62968317197,51.0643298312",
     "geom:latitude":51.040361,
     "geom:longitude":5.571397,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.040477,
     "lbl:longitude":5.581444,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Opglabbeek"
@@ -119,10 +131,13 @@
         102049975
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "begov:niscode":"71047"
+    },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241139,
-    "wof:geomhash":"6796cc7527fafce2f64ea22125e4f2bb",
+    "wof:geomhash":"9a24ee078caa62bf7089a9b6bee764a1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -134,7 +149,7 @@
         }
     ],
     "wof:id":1108830279,
-    "wof:lastmodified":1566611602,
+    "wof:lastmodified":1695878061,
     "wof:name":"Opglabbeek",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/028/1/1108830281.geojson
+++ b/data/110/883/028/1/1108830281.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.779123,
     "geom:longitude":4.87652,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.785891,
     "lbl:longitude":4.871289,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Hoegaarden"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24041",
         "eg:gisco_id":"BE_24041",
         "eurostat:nuts_2021_id":"24041"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241139,
     "wof:geomhash":"c754bff216e877a98cd0a6a9ce036253",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830281,
-    "wof:lastmodified":1684351664,
+    "wof:lastmodified":1695878094,
     "wof:name":"Hoegaarden",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/028/3/1108830283.geojson
+++ b/data/110/883/028/3/1108830283.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.212346,
     "geom:longitude":4.028735,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.215599,
     "lbl:longitude":4.024575,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0633\u062a\u0643\u064a\u0646\u0647"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"46024",
         "eg:gisco_id":"BE_46024",
         "eurostat:nuts_2021_id":"46024"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241139,
     "wof:geomhash":"04dc487924278c5f660521468f1c899b",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830283,
-    "wof:lastmodified":1684351664,
+    "wof:lastmodified":1695878094,
     "wof:name":"Stekene",
     "wof:parent_id":102049997,
     "wof:placetype":"localadmin",

--- a/data/110/883/028/7/1108830287.geojson
+++ b/data/110/883/028/7/1108830287.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.208041,
     "geom:longitude":3.627238,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.20432,
     "lbl:longitude":3.632545,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Kaprijke"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"43007",
         "eg:gisco_id":"BE_43007",
         "eurostat:nuts_2021_id":"43007"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241140,
     "wof:geomhash":"21f987b8322f1ec7a3c665a01301d88b",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830287,
-    "wof:lastmodified":1684351664,
+    "wof:lastmodified":1695878094,
     "wof:name":"Kaprijke",
     "wof:parent_id":102049995,
     "wof:placetype":"localadmin",

--- a/data/110/883/028/9/1108830289.geojson
+++ b/data/110/883/028/9/1108830289.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.150689,
     "geom:longitude":3.336679,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.152302,
     "lbl:longitude":3.337967,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Beernem"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"31003",
         "eg:gisco_id":"BE_31003",
         "eurostat:nuts_2021_id":"31003"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241140,
     "wof:geomhash":"a1875088cc803aef9aadb0ed7593a61c",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830289,
-    "wof:lastmodified":1684351664,
+    "wof:lastmodified":1695878095,
     "wof:name":"Beernem",
     "wof:parent_id":102050003,
     "wof:placetype":"localadmin",

--- a/data/110/883/029/1/1108830291.geojson
+++ b/data/110/883/029/1/1108830291.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.095717,
     "geom:longitude":4.514151,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.092547,
     "lbl:longitude":4.496546,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Duffel"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"12009",
         "eg:gisco_id":"BE_12009",
         "eurostat:nuts_2021_id":"12009"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241140,
     "wof:geomhash":"0bdf684ff1de1988c798fd55b67bbbf2",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830291,
-    "wof:lastmodified":1684351664,
+    "wof:lastmodified":1695878095,
     "wof:name":"Duffel",
     "wof:parent_id":102049985,
     "wof:placetype":"localadmin",

--- a/data/110/883/029/3/1108830293.geojson
+++ b/data/110/883/029/3/1108830293.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.093713,
     "geom:longitude":4.373279,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.093466,
     "lbl:longitude":4.373283,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ceb_x_preferred":[
         "Boom"
@@ -110,9 +122,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11005",
         "eg:gisco_id":"BE_11005",
         "eurostat:nuts_2021_id":"11005"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241140,
     "wof:geomhash":"e8cddfdaf68c8adc7012c6937851270b",
@@ -127,7 +141,7 @@
         }
     ],
     "wof:id":1108830293,
-    "wof:lastmodified":1684351664,
+    "wof:lastmodified":1695878095,
     "wof:name":"Boom",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/029/5/1108830295.geojson
+++ b/data/110/883/029/5/1108830295.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.968913,
     "geom:longitude":5.677961,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.968398,
     "lbl:longitude":5.679265,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Maasmechelen"
@@ -155,9 +167,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"73107",
         "eg:gisco_id":"BE_73107",
         "eurostat:nuts_2021_id":"73107"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241141,
     "wof:geomhash":"4d9e4ab4310a2dec6a12a4eb195adacc",
@@ -172,7 +186,7 @@
         }
     ],
     "wof:id":1108830295,
-    "wof:lastmodified":1684351664,
+    "wof:lastmodified":1695878095,
     "wof:name":"Maasmechelen",
     "wof:parent_id":1108782563,
     "wof:placetype":"localadmin",

--- a/data/110/883/029/7/1108830297.geojson
+++ b/data/110/883/029/7/1108830297.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.951208,
     "geom:longitude":4.247149,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.951566,
     "lbl:longitude":4.251261,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Merchtem"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23052",
         "eg:gisco_id":"BE_23052",
         "eurostat:nuts_2021_id":"23052"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241141,
     "wof:geomhash":"b55e4957a22df143128a53fcc6673cb3",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830297,
-    "wof:lastmodified":1684351664,
+    "wof:lastmodified":1695878096,
     "wof:name":"Merchtem",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/029/9/1108830299.geojson
+++ b/data/110/883/029/9/1108830299.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.799961,
     "geom:longitude":3.264588,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.799138,
     "lbl:longitude":3.263398,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Kortrijk"
@@ -251,9 +263,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"34022",
         "eg:gisco_id":"BE_34022",
         "eurostat:nuts_2021_id":"34022"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241142,
     "wof:geomhash":"10d711a56f2efdef0631710a405025f6",
@@ -268,7 +282,7 @@
         }
     ],
     "wof:id":1108830299,
-    "wof:lastmodified":1684351665,
+    "wof:lastmodified":1695878096,
     "wof:name":"Kortrijk",
     "wof:parent_id":102049961,
     "wof:placetype":"localadmin",

--- a/data/110/883/030/1/1108830301.geojson
+++ b/data/110/883/030/1/1108830301.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.055123,
     "geom:longitude":3.382273,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.059056,
     "lbl:longitude":3.368348,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Ruiselede"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"37012",
         "eg:gisco_id":"BE_37012",
         "eurostat:nuts_2021_id":"37012"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241142,
     "wof:geomhash":"cf03cd68b045f0a71c982e94a60e0476",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830301,
-    "wof:lastmodified":1684351665,
+    "wof:lastmodified":1695878096,
     "wof:name":"Ruiselede",
     "wof:parent_id":102049981,
     "wof:placetype":"localadmin",

--- a/data/110/883/030/5/1108830305.geojson
+++ b/data/110/883/030/5/1108830305.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.089033,
     "geom:longitude":2.963844,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.092803,
     "lbl:longitude":2.967772,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Koekelare"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"32010",
         "eg:gisco_id":"BE_32010",
         "eurostat:nuts_2021_id":"32010"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241143,
     "wof:geomhash":"03f019b1f435f5ae6dd749419b81203a",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830305,
-    "wof:lastmodified":1684351665,
+    "wof:lastmodified":1695878097,
     "wof:name":"Koekelare",
     "wof:parent_id":102049987,
     "wof:placetype":"localadmin",

--- a/data/110/883/030/7/1108830307.geojson
+++ b/data/110/883/030/7/1108830307.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.001418,
     "geom:longitude":5.069109,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.991629,
     "lbl:longitude":5.047285,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Diest"
@@ -143,9 +155,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24020",
         "eg:gisco_id":"BE_24020",
         "eurostat:nuts_2021_id":"24020"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241143,
     "wof:geomhash":"4a9fd6907a4cced8f86ca7fa5ed968dc",
@@ -160,7 +174,7 @@
         }
     ],
     "wof:id":1108830307,
-    "wof:lastmodified":1684351665,
+    "wof:lastmodified":1695878097,
     "wof:name":"Diest",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/030/9/1108830309.geojson
+++ b/data/110/883/030/9/1108830309.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.065986,
     "geom:longitude":4.305793,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.06337,
     "lbl:longitude":4.311272,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0628\u0648\u0631\u0633"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"12030",
         "eg:gisco_id":"BE_12041",
         "eurostat:nuts_2021_id":"12041"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241143,
     "wof:geomhash":"ec3177f24133fb2c87524041feeffdf2",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830309,
-    "wof:lastmodified":1684351665,
+    "wof:lastmodified":1695878097,
     "wof:name":"Puurs",
     "wof:parent_id":102049985,
     "wof:placetype":"localadmin",

--- a/data/110/883/031/1/1108830311.geojson
+++ b/data/110/883/031/1/1108830311.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.853522,
     "geom:longitude":3.620998,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.861118,
     "lbl:longitude":3.619798,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Oudenaarde"
@@ -185,9 +197,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"45035",
         "eg:gisco_id":"BE_45035",
         "eurostat:nuts_2021_id":"45035"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241144,
     "wof:geomhash":"f287d6101b013dccaf6d2fc14f0ea12d",
@@ -202,7 +216,7 @@
         }
     ],
     "wof:id":1108830311,
-    "wof:lastmodified":1684351665,
+    "wof:lastmodified":1695878098,
     "wof:name":"Oudenaarde",
     "wof:parent_id":102049963,
     "wof:placetype":"localadmin",

--- a/data/110/883/031/3/1108830313.geojson
+++ b/data/110/883/031/3/1108830313.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.941291,
     "geom:longitude":4.560667,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.940471,
     "lbl:longitude":4.549102,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Kampenhout"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23038",
         "eg:gisco_id":"BE_23038",
         "eurostat:nuts_2021_id":"23038"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241144,
     "wof:geomhash":"969d5b4db54395101189a38b06c7f590",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830313,
-    "wof:lastmodified":1684351666,
+    "wof:lastmodified":1695878098,
     "wof:name":"Kampenhout",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/031/5/1108830315.geojson
+++ b/data/110/883/031/5/1108830315.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.953752,
     "geom:longitude":3.018921,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.955347,
     "lbl:longitude":3.007241,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Staden"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"36019",
         "eg:gisco_id":"BE_36019",
         "eurostat:nuts_2021_id":"36019"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241144,
     "wof:geomhash":"0d7c84b5ae31085af1724a133e3c358f",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830315,
-    "wof:lastmodified":1684351666,
+    "wof:lastmodified":1695878098,
     "wof:name":"Staden",
     "wof:parent_id":102049977,
     "wof:placetype":"localadmin",

--- a/data/110/883/031/7/1108830317.geojson
+++ b/data/110/883/031/7/1108830317.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.126631,
     "geom:longitude":3.134319,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.12592,
     "lbl:longitude":3.142175,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Zedelgem"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"31040",
         "eg:gisco_id":"BE_31040",
         "eurostat:nuts_2021_id":"31040"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241144,
     "wof:geomhash":"f12d964dc5d8251bfbee44e1725f8e28",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830317,
-    "wof:lastmodified":1684351666,
+    "wof:lastmodified":1695878098,
     "wof:name":"Zedelgem",
     "wof:parent_id":102050003,
     "wof:placetype":"localadmin",

--- a/data/110/883/031/9/1108830319.geojson
+++ b/data/110/883/031/9/1108830319.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.17978,
     "geom:longitude":4.739125,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.180566,
     "lbl:longitude":4.739121,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Grobbendonk"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13010",
         "eg:gisco_id":"BE_13010",
         "eurostat:nuts_2021_id":"13010"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241145,
     "wof:geomhash":"84d7699eb04aebe35cc34b602703195b",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830319,
-    "wof:lastmodified":1684351666,
+    "wof:lastmodified":1695878098,
     "wof:name":"Grobbendonk",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/032/3/1108830323.geojson
+++ b/data/110/883/032/3/1108830323.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.019915,
     "geom:longitude":5.289146,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.020602,
     "lbl:longitude":5.288179,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Heusden-Zolder"
@@ -161,9 +173,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71070",
         "eg:gisco_id":"BE_71070",
         "eurostat:nuts_2021_id":"71070"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241145,
     "wof:geomhash":"544d22c6c37aca38495a036478f4f4d5",
@@ -178,7 +192,7 @@
         }
     ],
     "wof:id":1108830323,
-    "wof:lastmodified":1684351666,
+    "wof:lastmodified":1695878099,
     "wof:name":"Heusden-Zolder",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/032/5/1108830325.geojson
+++ b/data/110/883/032/5/1108830325.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.959559,
     "geom:longitude":4.732274,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.961411,
     "lbl:longitude":4.732273,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Rotselaar"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24094",
         "eg:gisco_id":"BE_24094",
         "eurostat:nuts_2021_id":"24094"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241145,
     "wof:geomhash":"aeda0149b0c5a6aa4dd16faa727e4fc5",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830325,
-    "wof:lastmodified":1684351666,
+    "wof:lastmodified":1695878099,
     "wof:name":"Rotselaar",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/032/7/1108830327.geojson
+++ b/data/110/883/032/7/1108830327.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.860163,
     "geom:longitude":3.271596,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.859463,
     "lbl:longitude":3.269058,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0643\u0648\u0631\u0646\u064a"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"34023",
         "eg:gisco_id":"BE_34023",
         "eurostat:nuts_2021_id":"34023"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241145,
     "wof:geomhash":"6fb51e3eece3dd36c4de6d088288d81c",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830327,
-    "wof:lastmodified":1684351666,
+    "wof:lastmodified":1695878099,
     "wof:name":"Kuurne",
     "wof:parent_id":102049961,
     "wof:placetype":"localadmin",

--- a/data/110/883/032/9/1108830329.geojson
+++ b/data/110/883/032/9/1108830329.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.994493,
     "geom:longitude":3.870233,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.993787,
     "lbl:longitude":3.870239,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Wetteren"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"42025",
         "eg:gisco_id":"BE_42025",
         "eurostat:nuts_2021_id":"42025"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241146,
     "wof:geomhash":"957181bae5c55b8fafafef3a94f243ad",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830329,
-    "wof:lastmodified":1684351666,
+    "wof:lastmodified":1695878099,
     "wof:name":"Wetteren",
     "wof:parent_id":102049979,
     "wof:placetype":"localadmin",

--- a/data/110/883/033/1/1108830331.geojson
+++ b/data/110/883/033/1/1108830331.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.966128,
     "geom:longitude":3.945645,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.963454,
     "lbl:longitude":3.93639,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ceb_x_preferred":[
         "Lede"
@@ -65,9 +77,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"41034",
         "eg:gisco_id":"BE_41034",
         "eurostat:nuts_2021_id":"41034"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241146,
     "wof:geomhash":"473757dfa540ad5950db7a67d65b2792",
@@ -82,7 +96,7 @@
         }
     ],
     "wof:id":1108830331,
-    "wof:lastmodified":1684351667,
+    "wof:lastmodified":1695878100,
     "wof:name":"Lede",
     "wof:parent_id":102049967,
     "wof:placetype":"localadmin",

--- a/data/110/883/033/3/1108830333.geojson
+++ b/data/110/883/033/3/1108830333.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.062324,
     "geom:longitude":3.095491,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.058831,
     "lbl:longitude":3.091611,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Torhout"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"31033",
         "eg:gisco_id":"BE_31033",
         "eurostat:nuts_2021_id":"31033"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241147,
     "wof:geomhash":"7213195e547cee66fb5c830e32b0c90b",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830333,
-    "wof:lastmodified":1684351667,
+    "wof:lastmodified":1695878100,
     "wof:name":"Torhout",
     "wof:parent_id":102050003,
     "wof:placetype":"localadmin",

--- a/data/110/883/033/5/1108830335.geojson
+++ b/data/110/883/033/5/1108830335.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.970002,
     "geom:longitude":2.896439,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.971251,
     "lbl:longitude":2.902097,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Houthulst"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"32006",
         "eg:gisco_id":"BE_32006",
         "eurostat:nuts_2021_id":"32006"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241147,
     "wof:geomhash":"9d6876da62ea2a7ba39cbf02000620b9",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830335,
-    "wof:lastmodified":1684351667,
+    "wof:lastmodified":1695878100,
     "wof:name":"Houthulst",
     "wof:parent_id":102049987,
     "wof:placetype":"localadmin",

--- a/data/110/883/033/7/1108830337.geojson
+++ b/data/110/883/033/7/1108830337.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.923379,
     "geom:longitude":4.896554,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.924058,
     "lbl:longitude":4.890067,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bar_x_preferred":[
         "Tielt-Winge"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24135",
         "eg:gisco_id":"BE_24135",
         "eurostat:nuts_2021_id":"24135"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241148,
     "wof:geomhash":"2135f52133cd02fb513315ea81840cc3",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830337,
-    "wof:lastmodified":1684351667,
+    "wof:lastmodified":1695878101,
     "wof:name":"Tielt-Winge",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/034/1/1108830341.geojson
+++ b/data/110/883/034/1/1108830341.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.880614,
     "geom:longitude":3.402513,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.879432,
     "lbl:longitude":3.410179,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Waregem"
@@ -176,9 +188,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"34040",
         "eg:gisco_id":"BE_34040",
         "eurostat:nuts_2021_id":"34040"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241148,
     "wof:geomhash":"dc023f046d02befa73946640b09fa5a7",
@@ -193,7 +207,7 @@
         }
     ],
     "wof:id":1108830341,
-    "wof:lastmodified":1684351667,
+    "wof:lastmodified":1695878101,
     "wof:name":"Waregem",
     "wof:parent_id":102049961,
     "wof:placetype":"localadmin",

--- a/data/110/883/034/3/1108830343.geojson
+++ b/data/110/883/034/3/1108830343.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.944681,
     "geom:longitude":4.376541,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.948619,
     "lbl:longitude":4.381844,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Grimbergen"
@@ -146,9 +158,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23025",
         "eg:gisco_id":"BE_23025",
         "eurostat:nuts_2021_id":"23025"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241148,
     "wof:geomhash":"6e508ffbdcea9dbfffee43f940ef5327",
@@ -163,7 +177,7 @@
         }
     ],
     "wof:id":1108830343,
-    "wof:lastmodified":1684351667,
+    "wof:lastmodified":1695878101,
     "wof:name":"Grimbergen",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/034/5/1108830345.geojson
+++ b/data/110/883/034/5/1108830345.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.893133,
     "geom:longitude":5.023111,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.896226,
     "lbl:longitude":5.021955,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Kortenaken"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24054",
         "eg:gisco_id":"BE_24054",
         "eurostat:nuts_2021_id":"24054"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241148,
     "wof:geomhash":"237fb1979b3242f705ae31dc6b8ca76a",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830345,
-    "wof:lastmodified":1684351667,
+    "wof:lastmodified":1695878102,
     "wof:name":"Kortenaken",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/034/7/1108830347.geojson
+++ b/data/110/883/034/7/1108830347.geojson
@@ -14,17 +14,29 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002819,
-    "geom:area_square_m":21863268.522436,
+    "geom:area_square_m":21863268.522435,
     "geom:bbox":"3.56123297297,51.1188462875,3.64782923068,51.1755254224",
     "geom:latitude":51.152085,
     "geom:longitude":3.609667,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.152214,
     "lbl:longitude":3.612615,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Waarschoot"
@@ -110,10 +122,13 @@
         102049989
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "begov:niscode":"44072"
+    },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241149,
-    "wof:geomhash":"c58fde0eb3abebd81cbbd75997ec0085",
+    "wof:geomhash":"2ba4bc8c659e290318487b4cfd74336b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -125,7 +140,7 @@
         }
     ],
     "wof:id":1108830347,
-    "wof:lastmodified":1566611663,
+    "wof:lastmodified":1695878062,
     "wof:name":"Waarschoot",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/034/9/1108830349.geojson
+++ b/data/110/883/034/9/1108830349.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.305295,
     "geom:longitude":4.885121,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.304821,
     "lbl:longitude":4.887758,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Vosselaar"
@@ -119,9 +131,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13046",
         "eg:gisco_id":"BE_13046",
         "eurostat:nuts_2021_id":"13046"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241149,
     "wof:geomhash":"9777b68a5323570e100fc35985e40510",
@@ -136,7 +150,7 @@
         }
     ],
     "wof:id":1108830349,
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695878102,
     "wof:name":"Vosselaar",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/035/1/1108830351.geojson
+++ b/data/110/883/035/1/1108830351.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.74422,
     "geom:longitude":4.147625,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.749509,
     "lbl:longitude":4.162888,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Pepingen"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23064",
         "eg:gisco_id":"BE_23064",
         "eurostat:nuts_2021_id":"23064"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241149,
     "wof:geomhash":"3394cf6158a551018b717eb8fc245932",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830351,
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695878102,
     "wof:name":"Pepingen",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/035/3/1108830353.geojson
+++ b/data/110/883/035/3/1108830353.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.054036,
     "geom:longitude":4.368523,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.060576,
     "lbl:longitude":4.363475,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Willebroek"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"12040",
         "eg:gisco_id":"BE_12040",
         "eurostat:nuts_2021_id":"12040"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241150,
     "wof:geomhash":"0561b5f8f67e571af9b86041d485446c",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830353,
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695878103,
     "wof:name":"Willebroek",
     "wof:parent_id":102049985,
     "wof:placetype":"localadmin",

--- a/data/110/883/035/5/1108830355.geojson
+++ b/data/110/883/035/5/1108830355.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.988979,
     "geom:longitude":4.864616,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.990032,
     "lbl:longitude":4.872738,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Aarschot"
@@ -158,9 +170,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24001",
         "eg:gisco_id":"BE_24001",
         "eurostat:nuts_2021_id":"24001"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241150,
     "wof:geomhash":"13dcde42cc9c7135e34668c106bd7e86",
@@ -175,7 +189,7 @@
         }
     ],
     "wof:id":1108830355,
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695878103,
     "wof:name":"Aarschot",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/035/9/1108830359.geojson
+++ b/data/110/883/035/9/1108830359.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.804783,
     "geom:longitude":5.340926,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.79901,
     "lbl:longitude":5.342103,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Borgloon"
@@ -143,9 +155,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"73009",
         "eg:gisco_id":"BE_73009",
         "eurostat:nuts_2021_id":"73009"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241150,
     "wof:geomhash":"158dad43ff9a1321c49043416eec8532",
@@ -160,7 +174,7 @@
         }
     ],
     "wof:id":1108830359,
-    "wof:lastmodified":1684351668,
+    "wof:lastmodified":1695878103,
     "wof:name":"Borgloon",
     "wof:parent_id":1108782563,
     "wof:placetype":"localadmin",

--- a/data/110/883/036/1/1108830361.geojson
+++ b/data/110/883/036/1/1108830361.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.870436,
     "geom:longitude":3.892465,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.86553,
     "lbl:longitude":3.892462,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Herzele"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"41027",
         "eg:gisco_id":"BE_41027",
         "eurostat:nuts_2021_id":"41027"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241151,
     "wof:geomhash":"d70a4b8c0d3676b50b864b00cd2c181b",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830361,
-    "wof:lastmodified":1684351669,
+    "wof:lastmodified":1695878104,
     "wof:name":"Herzele",
     "wof:parent_id":102049967,
     "wof:placetype":"localadmin",

--- a/data/110/883/036/3/1108830363.geojson
+++ b/data/110/883/036/3/1108830363.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.186052,
     "geom:longitude":3.012258,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.18262,
     "lbl:longitude":3.01318,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Oudenburg"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"35014",
         "eg:gisco_id":"BE_35014",
         "eurostat:nuts_2021_id":"35014"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241151,
     "wof:geomhash":"247a326fff4cc5d28402ffc78fd0bf77",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830363,
-    "wof:lastmodified":1684351669,
+    "wof:lastmodified":1695878104,
     "wof:name":"Oudenburg",
     "wof:parent_id":102049999,
     "wof:placetype":"localadmin",

--- a/data/110/883/036/5/1108830365.geojson
+++ b/data/110/883/036/5/1108830365.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.19432,
     "geom:longitude":3.562335,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.193807,
     "lbl:longitude":3.563321,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bel_x_preferred":[
         "\u042d\u043a\u043b\u0430"
@@ -149,9 +161,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"43005",
         "eg:gisco_id":"BE_43005",
         "eurostat:nuts_2021_id":"43005"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241152,
     "wof:geomhash":"da8f4c14bc59a053859ac6a2c54822fe",
@@ -166,7 +180,7 @@
         }
     ],
     "wof:id":1108830365,
-    "wof:lastmodified":1684351669,
+    "wof:lastmodified":1695878104,
     "wof:name":"Eeklo",
     "wof:parent_id":102049995,
     "wof:placetype":"localadmin",

--- a/data/110/883/036/7/1108830367.geojson
+++ b/data/110/883/036/7/1108830367.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.998068,
     "geom:longitude":4.968573,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.000591,
     "lbl:longitude":4.963713,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Scherpenheuvel-Zichem"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24134",
         "eg:gisco_id":"BE_24134",
         "eurostat:nuts_2021_id":"24134"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241152,
     "wof:geomhash":"5803d9205ef6669b3122f710d03e5736",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830367,
-    "wof:lastmodified":1684351669,
+    "wof:lastmodified":1695878104,
     "wof:name":"Scherpenheuvel-Zichem",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/036/9/1108830369.geojson
+++ b/data/110/883/036/9/1108830369.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.730512,
     "geom:longitude":3.362812,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.726791,
     "lbl:longitude":3.353341,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Spiere-Helkijn"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"34043",
         "eg:gisco_id":"BE_34043",
         "eurostat:nuts_2021_id":"34043"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241152,
     "wof:geomhash":"91b78085f5a2a09cb80a75807479c73e",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830369,
-    "wof:lastmodified":1684351669,
+    "wof:lastmodified":1695878105,
     "wof:name":"Spiere-Helkijn",
     "wof:parent_id":102049961,
     "wof:placetype":"localadmin",

--- a/data/110/883/037/1/1108830371.geojson
+++ b/data/110/883/037/1/1108830371.geojson
@@ -14,17 +14,29 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005044,
-    "geom:area_square_m":39145448.888984,
+    "geom:area_square_m":39145448.888986,
     "geom:bbox":"3.50987689121,51.0901758464,3.61229202714,51.1697729879",
     "geom:latitude":51.126009,
     "geom:longitude":3.556228,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.123184,
     "lbl:longitude":3.552071,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Zomergem"
@@ -113,10 +125,13 @@
         102049989
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "begov:niscode":"44080"
+    },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241153,
-    "wof:geomhash":"9174e2bf5d0a2f1c6009f45bfe7df890",
+    "wof:geomhash":"83c03a66966a5774fa288c1b38238bf1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -128,7 +143,7 @@
         }
     ],
     "wof:id":1108830371,
-    "wof:lastmodified":1566611585,
+    "wof:lastmodified":1695878060,
     "wof:name":"Zomergem",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/037/3/1108830373.geojson
+++ b/data/110/883/037/3/1108830373.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.440457,
     "geom:longitude":4.763728,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.456352,
     "lbl:longitude":4.748394,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0647\u0648\u062e\u0633\u062a\u0631\u0627\u062a\u0646"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13014",
         "eg:gisco_id":"BE_13014",
         "eurostat:nuts_2021_id":"13014"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241153,
     "wof:geomhash":"4e0cc5f2eff364c0ee940fd9cbe786d0",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830373,
-    "wof:lastmodified":1684351669,
+    "wof:lastmodified":1695878105,
     "wof:name":"Hoogstraten",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/037/7/1108830377.geojson
+++ b/data/110/883/037/7/1108830377.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.328494,
     "geom:longitude":4.376764,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.326951,
     "lbl:longitude":4.372288,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bel_x_preferred":[
         "\u0421\u0442\u0430\u0431\u0440\u0443\u043a"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11044",
         "eg:gisco_id":"BE_11044",
         "eurostat:nuts_2021_id":"11044"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241153,
     "wof:geomhash":"6cbbd15c6081f4f673784c3fcffe69bc",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830377,
-    "wof:lastmodified":1684351669,
+    "wof:lastmodified":1695878105,
     "wof:name":"Stabroek",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/037/9/1108830379.geojson
+++ b/data/110/883/037/9/1108830379.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.100223,
     "geom:longitude":5.160826,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.097761,
     "lbl:longitude":5.161851,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0647\u0627\u0645"
@@ -230,9 +242,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71069",
         "eg:gisco_id":"BE_71069",
         "eurostat:nuts_2021_id":"71069"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241153,
     "wof:geomhash":"8ba4b432e1fe97f737eb5a4803bfe313",
@@ -247,7 +261,7 @@
         }
     ],
     "wof:id":1108830379,
-    "wof:lastmodified":1684351669,
+    "wof:lastmodified":1695878105,
     "wof:name":"Ham",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/038/1/1108830381.geojson
+++ b/data/110/883/038/1/1108830381.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.050688,
     "geom:longitude":4.636366,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.050316,
     "lbl:longitude":4.640632,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Putte"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"12029",
         "eg:gisco_id":"BE_12029",
         "eurostat:nuts_2021_id":"12029"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241154,
     "wof:geomhash":"7ad5a7bc133cd6e829fae06d01caf11e",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830381,
-    "wof:lastmodified":1684351670,
+    "wof:lastmodified":1695878106,
     "wof:name":"Putte",
     "wof:parent_id":102049985,
     "wof:placetype":"localadmin",

--- a/data/110/883/038/3/1108830383.geojson
+++ b/data/110/883/038/3/1108830383.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.078229,
     "geom:longitude":3.445278,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.08512,
     "lbl:longitude":3.446717,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Aalter"
@@ -158,9 +170,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"44001",
         "eg:gisco_id":"BE_44084",
         "eurostat:nuts_2021_id":"44084"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241154,
     "wof:geomhash":"ff6581ee6b55ffabc5be85c6a59478b0",
@@ -175,7 +189,7 @@
         }
     ],
     "wof:id":1108830383,
-    "wof:lastmodified":1684351670,
+    "wof:lastmodified":1695878106,
     "wof:name":"Aalter",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/038/5/1108830385.geojson
+++ b/data/110/883/038/5/1108830385.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.335943,
     "geom:longitude":4.6282,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.333514,
     "lbl:longitude":4.61165,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "reversegeo:latitude":51.333514,
     "reversegeo:longitude":4.61165,
@@ -53,9 +65,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11009",
         "eg:gisco_id":"BE_11009",
         "eurostat:nuts_2021_id":"11009"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241154,
     "wof:geomhash":"2338982e190f5c6a752c22fdd86b7d5d",
@@ -70,7 +84,7 @@
         }
     ],
     "wof:id":1108830385,
-    "wof:lastmodified":1684351670,
+    "wof:lastmodified":1695878106,
     "wof:name":"Brecht",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/038/7/1108830387.geojson
+++ b/data/110/883/038/7/1108830387.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.133091,
     "geom:longitude":4.20579,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.143713,
     "lbl:longitude":4.212351,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Temse"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"46025",
         "eg:gisco_id":"BE_46025",
         "eurostat:nuts_2021_id":"46025"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241155,
     "wof:geomhash":"ccc263c1a7c3475e185f50922c458338",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830387,
-    "wof:lastmodified":1684351670,
+    "wof:lastmodified":1695878106,
     "wof:name":"Temse",
     "wof:parent_id":102049997,
     "wof:placetype":"localadmin",

--- a/data/110/883/038/9/1108830389.geojson
+++ b/data/110/883/038/9/1108830389.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.035988,
     "geom:longitude":5.712127,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.038417,
     "lbl:longitude":5.720927,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Dilsen-Stokkem"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"72041",
         "eg:gisco_id":"BE_72041",
         "eurostat:nuts_2021_id":"72041"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241155,
     "wof:geomhash":"725b38b96d9048a5d784e976059aaf6a",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830389,
-    "wof:lastmodified":1684351670,
+    "wof:lastmodified":1695878107,
     "wof:name":"Dilsen-Stokkem",
     "wof:parent_id":102049993,
     "wof:placetype":"localadmin",

--- a/data/110/883/039/1/1108830391.geojson
+++ b/data/110/883/039/1/1108830391.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.853067,
     "geom:longitude":5.405896,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.852696,
     "lbl:longitude":5.406632,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Kortessem"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"73040",
         "eg:gisco_id":"BE_73040",
         "eurostat:nuts_2021_id":"73040"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241155,
     "wof:geomhash":"f5fa3f8ca4ce437605e34283380b804a",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830391,
-    "wof:lastmodified":1684351670,
+    "wof:lastmodified":1695878107,
     "wof:name":"Kortessem",
     "wof:parent_id":1108782563,
     "wof:placetype":"localadmin",

--- a/data/110/883/039/5/1108830395.geojson
+++ b/data/110/883/039/5/1108830395.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.157804,
     "geom:longitude":4.291863,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.155926,
     "lbl:longitude":4.297673,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Kruibeke"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"46013",
         "eg:gisco_id":"BE_46013",
         "eurostat:nuts_2021_id":"46013"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241156,
     "wof:geomhash":"7cba6c45c0ed2fe6c76e0e094a9b54bf",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830395,
-    "wof:lastmodified":1684351670,
+    "wof:lastmodified":1695878107,
     "wof:name":"Kruibeke",
     "wof:parent_id":102049997,
     "wof:placetype":"localadmin",

--- a/data/110/883/039/7/1108830397.geojson
+++ b/data/110/883/039/7/1108830397.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.936836,
     "geom:longitude":3.133573,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.936896,
     "lbl:longitude":3.132481,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Roeselare"
@@ -182,9 +194,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"36015",
         "eg:gisco_id":"BE_36015",
         "eurostat:nuts_2021_id":"36015"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241156,
     "wof:geomhash":"5be2345b81d82750ce4d5c2ea6560809",
@@ -199,7 +213,7 @@
         }
     ],
     "wof:id":1108830397,
-    "wof:lastmodified":1684351670,
+    "wof:lastmodified":1695878107,
     "wof:name":"Roeselare",
     "wof:parent_id":102049977,
     "wof:placetype":"localadmin",

--- a/data/110/883/039/9/1108830399.geojson
+++ b/data/110/883/039/9/1108830399.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.722825,
     "geom:longitude":4.036709,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.719995,
     "lbl:longitude":4.035501,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ceb_x_preferred":[
         "Herne"
@@ -95,9 +107,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23032",
         "eg:gisco_id":"BE_23032",
         "eurostat:nuts_2021_id":"23032"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241156,
     "wof:geomhash":"899b8f7537f846df8fc53996a3303648",
@@ -112,7 +126,7 @@
         }
     ],
     "wof:id":1108830399,
-    "wof:lastmodified":1684351671,
+    "wof:lastmodified":1695878108,
     "wof:name":"Herne",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/040/1/1108830401.geojson
+++ b/data/110/883/040/1/1108830401.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.047396,
     "geom:longitude":2.85424,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.040778,
     "lbl:longitude":2.852276,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Diksmuide"
@@ -146,9 +158,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"32003",
         "eg:gisco_id":"BE_32003",
         "eurostat:nuts_2021_id":"32003"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241157,
     "wof:geomhash":"d3e6cfbd6a7ad18c3f487989fb8b4542",
@@ -163,7 +177,7 @@
         }
     ],
     "wof:id":1108830401,
-    "wof:lastmodified":1684351671,
+    "wof:lastmodified":1695878108,
     "wof:name":"Diksmuide",
     "wof:parent_id":102049987,
     "wof:placetype":"localadmin",

--- a/data/110/883/040/3/1108830403.geojson
+++ b/data/110/883/040/3/1108830403.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.826037,
     "geom:longitude":4.004802,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.822326,
     "lbl:longitude":4.006288,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Ninove"
@@ -140,9 +152,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"41048",
         "eg:gisco_id":"BE_41048",
         "eurostat:nuts_2021_id":"41048"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241157,
     "wof:geomhash":"49a8f20ab1a05f7f802e81631681ea78",
@@ -157,7 +171,7 @@
         }
     ],
     "wof:id":1108830403,
-    "wof:lastmodified":1684351671,
+    "wof:lastmodified":1695878108,
     "wof:name":"Ninove",
     "wof:parent_id":102049967,
     "wof:placetype":"localadmin",

--- a/data/110/883/040/5/1108830405.geojson
+++ b/data/110/883/040/5/1108830405.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.211309,
     "geom:longitude":4.679243,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.215827,
     "lbl:longitude":4.678313,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Zandhoven"
@@ -119,9 +131,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11054",
         "eg:gisco_id":"BE_11054",
         "eurostat:nuts_2021_id":"11054"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241158,
     "wof:geomhash":"14d78e60eb175700f106d7ca3c88b2a6",
@@ -136,7 +150,7 @@
         }
     ],
     "wof:id":1108830405,
-    "wof:lastmodified":1684351671,
+    "wof:lastmodified":1695878109,
     "wof:name":"Zandhoven",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/040/7/1108830407.geojson
+++ b/data/110/883/040/7/1108830407.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.028669,
     "geom:longitude":4.45024,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.032041,
     "lbl:longitude":4.436721,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Mechelen"
@@ -227,9 +239,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"12025",
         "eg:gisco_id":"BE_12025",
         "eurostat:nuts_2021_id":"12025"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241158,
     "wof:geomhash":"4da4f5636fba4759dd5832c608067b73",
@@ -244,7 +258,7 @@
         }
     ],
     "wof:id":1108830407,
-    "wof:lastmodified":1684351671,
+    "wof:lastmodified":1695878109,
     "wof:name":"Mechelen",
     "wof:parent_id":102049985,
     "wof:placetype":"localadmin",

--- a/data/110/883/040/9/1108830409.geojson
+++ b/data/110/883/040/9/1108830409.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.830091,
     "geom:longitude":4.767388,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.831054,
     "lbl:longitude":4.773748,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Bierbeek"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24011",
         "eg:gisco_id":"BE_24011",
         "eurostat:nuts_2021_id":"24011"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241158,
     "wof:geomhash":"a06548a2515b4adf3f5185c4ec9af858",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830409,
-    "wof:lastmodified":1684351672,
+    "wof:lastmodified":1695878110,
     "wof:name":"Bierbeek",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/041/3/1108830413.geojson
+++ b/data/110/883/041/3/1108830413.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.143337,
     "geom:longitude":3.70817,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.141869,
     "lbl:longitude":3.715073,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Evergem"
@@ -143,9 +155,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"44019",
         "eg:gisco_id":"BE_44019",
         "eurostat:nuts_2021_id":"44019"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241159,
     "wof:geomhash":"d1c2814660e7f5f60fe590e3b1315229",
@@ -160,7 +174,7 @@
         }
     ],
     "wof:id":1108830413,
-    "wof:lastmodified":1684351672,
+    "wof:lastmodified":1695878110,
     "wof:name":"Evergem",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/041/5/1108830415.geojson
+++ b/data/110/883/041/5/1108830415.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.398857,
     "geom:longitude":4.468647,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.385493,
     "lbl:longitude":4.476105,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Kalmthout"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11022",
         "eg:gisco_id":"BE_11022",
         "eurostat:nuts_2021_id":"11022"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241159,
     "wof:geomhash":"b02dae093f2024ca0f29d1d1352fa7ec",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830415,
-    "wof:lastmodified":1684351672,
+    "wof:lastmodified":1695878110,
     "wof:name":"Kalmthout",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/041/7/1108830417.geojson
+++ b/data/110/883/041/7/1108830417.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.027599,
     "geom:longitude":4.090702,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.038248,
     "lbl:longitude":4.107148,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Dendermonde"
@@ -191,9 +203,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"42006",
         "eg:gisco_id":"BE_42006",
         "eurostat:nuts_2021_id":"42006"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241159,
     "wof:geomhash":"1a5bfcb67fe7e0aba6ad2af5a2d2ee37",
@@ -208,7 +222,7 @@
         }
     ],
     "wof:id":1108830417,
-    "wof:lastmodified":1684351672,
+    "wof:lastmodified":1695878110,
     "wof:name":"Dendermonde",
     "wof:parent_id":102049979,
     "wof:placetype":"localadmin",

--- a/data/110/883/041/9/1108830419.geojson
+++ b/data/110/883/041/9/1108830419.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.848353,
     "geom:longitude":3.527595,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.846913,
     "lbl:longitude":3.539028,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Wortegem-Petegem"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"45061",
         "eg:gisco_id":"BE_45061",
         "eurostat:nuts_2021_id":"45061"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241159,
     "wof:geomhash":"6ae799faa7a674ab8c4bad903aa4ca97",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830419,
-    "wof:lastmodified":1684351672,
+    "wof:lastmodified":1695878110,
     "wof:name":"Wortegem-Petegem",
     "wof:parent_id":102049963,
     "wof:placetype":"localadmin",

--- a/data/110/883/042/1/1108830421.geojson
+++ b/data/110/883/042/1/1108830421.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.90728,
     "geom:longitude":4.215345,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.911709,
     "lbl:longitude":4.207365,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Asse"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23002",
         "eg:gisco_id":"BE_23002",
         "eurostat:nuts_2021_id":"23002"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241160,
     "wof:geomhash":"50a2d6b943440243ca125cbdfe5a3075",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830421,
-    "wof:lastmodified":1684351672,
+    "wof:lastmodified":1695878111,
     "wof:name":"Asse",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/042/3/1108830423.geojson
+++ b/data/110/883/042/3/1108830423.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.260623,
     "geom:longitude":4.369486,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.246664,
     "lbl:longitude":4.402453,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "reversegeo:latitude":51.246664,
     "reversegeo:longitude":4.402453,
@@ -53,9 +65,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11002",
         "eg:gisco_id":"BE_11002",
         "eurostat:nuts_2021_id":"11002"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241160,
     "wof:geomhash":"7e1ffc54c7e279961efe96a122476c38",
@@ -70,7 +84,7 @@
         }
     ],
     "wof:id":1108830423,
-    "wof:lastmodified":1684351672,
+    "wof:lastmodified":1695878111,
     "wof:name":"Antwerpen",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/042/5/1108830425.geojson
+++ b/data/110/883/042/5/1108830425.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.92894,
     "geom:longitude":3.685502,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.933725,
     "lbl:longitude":3.680026,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Gavere"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"44020",
         "eg:gisco_id":"BE_44020",
         "eurostat:nuts_2021_id":"44020"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241161,
     "wof:geomhash":"87814c9b1aaf82173a0ac3574fda411e",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830425,
-    "wof:lastmodified":1684351673,
+    "wof:lastmodified":1695878112,
     "wof:name":"Gavere",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/042/7/1108830427.geojson
+++ b/data/110/883/042/7/1108830427.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.835094,
     "geom:longitude":5.101172,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.842748,
     "lbl:longitude":5.106506,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Zoutleeuw"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24130",
         "eg:gisco_id":"BE_24130",
         "eurostat:nuts_2021_id":"24130"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241161,
     "wof:geomhash":"7321ec3834541db0767ca4f918130776",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830427,
-    "wof:lastmodified":1684351673,
+    "wof:lastmodified":1695878112,
     "wof:name":"Zoutleeuw",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/043/1/1108830431.geojson
+++ b/data/110/883/043/1/1108830431.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.206775,
     "geom:longitude":4.518949,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.205674,
     "lbl:longitude":4.519553,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Wommelgem"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11052",
         "eg:gisco_id":"BE_11052",
         "eurostat:nuts_2021_id":"11052"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241162,
     "wof:geomhash":"66d58dc035c6d1f87c8b5f95f51c2611",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830431,
-    "wof:lastmodified":1684351673,
+    "wof:lastmodified":1695878112,
     "wof:name":"Wommelgem",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/043/3/1108830433.geojson
+++ b/data/110/883/043/3/1108830433.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.22458,
     "geom:longitude":4.323298,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.229166,
     "lbl:longitude":4.320505,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:cat_x_preferred":[
         "Zwijndrecht"
@@ -107,9 +119,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11056",
         "eg:gisco_id":"BE_11056",
         "eurostat:nuts_2021_id":"11056"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241162,
     "wof:geomhash":"5da543d6d2dcdeaedd1967348a6ffae6",
@@ -124,7 +138,7 @@
         }
     ],
     "wof:id":1108830433,
-    "wof:lastmodified":1684351673,
+    "wof:lastmodified":1695878113,
     "wof:name":"Zwijndrecht",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/043/5/1108830435.geojson
+++ b/data/110/883/043/5/1108830435.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.929692,
     "geom:longitude":4.801831,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.930026,
     "lbl:longitude":4.820126,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bar_x_preferred":[
         "Holsbeek"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24043",
         "eg:gisco_id":"BE_24043",
         "eurostat:nuts_2021_id":"24043"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241163,
     "wof:geomhash":"5146c815e44b8202ad975287e6d11e25",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830435,
-    "wof:lastmodified":1684351673,
+    "wof:lastmodified":1695878113,
     "wof:name":"Holsbeek",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/043/7/1108830437.geojson
+++ b/data/110/883/043/7/1108830437.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.726354,
     "geom:longitude":4.237006,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.723702,
     "lbl:longitude":4.237002,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Halle"
@@ -170,9 +182,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23027",
         "eg:gisco_id":"BE_23027",
         "eurostat:nuts_2021_id":"23027"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241163,
     "wof:geomhash":"89ad4f1c3c86946406845d8a9bccf731",
@@ -187,7 +201,7 @@
         }
     ],
     "wof:id":1108830437,
-    "wof:lastmodified":1684351673,
+    "wof:lastmodified":1695878113,
     "wof:name":"Halle",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/043/9/1108830439.geojson
+++ b/data/110/883/043/9/1108830439.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.009569,
     "geom:longitude":3.622227,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.010917,
     "lbl:longitude":3.624397,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Sint-Martens-Latem"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"44064",
         "eg:gisco_id":"BE_44064",
         "eurostat:nuts_2021_id":"44064"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241163,
     "wof:geomhash":"9d359102bc0330c6255d59a2b09cc585",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830439,
-    "wof:lastmodified":1684351674,
+    "wof:lastmodified":1695878114,
     "wof:name":"Sint-Martens-Latem",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/044/1/1108830441.geojson
+++ b/data/110/883/044/1/1108830441.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.8784,
     "geom:longitude":5.290574,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.876858,
     "lbl:longitude":5.289738,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ceb_x_preferred":[
         "Alken"
@@ -92,9 +104,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"73001",
         "eg:gisco_id":"BE_73001",
         "eurostat:nuts_2021_id":"73001"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241164,
     "wof:geomhash":"2ffd34d530304c9e1c17f60c48643582",
@@ -109,7 +123,7 @@
         }
     ],
     "wof:id":1108830441,
-    "wof:lastmodified":1684351674,
+    "wof:lastmodified":1695878114,
     "wof:name":"Alken",
     "wof:parent_id":1108782563,
     "wof:placetype":"localadmin",

--- a/data/110/883/044/3/1108830443.geojson
+++ b/data/110/883/044/3/1108830443.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.158604,
     "geom:longitude":5.182984,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.153711,
     "lbl:longitude":5.161326,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Balen"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13003",
         "eg:gisco_id":"BE_13003",
         "eurostat:nuts_2021_id":"13003"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241164,
     "wof:geomhash":"3e69bb2e8946bad99549d248b5e15f6f",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830443,
-    "wof:lastmodified":1684351674,
+    "wof:lastmodified":1695878114,
     "wof:name":"Balen",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/044/5/1108830445.geojson
+++ b/data/110/883/044/5/1108830445.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.832132,
     "geom:longitude":3.694493,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.832289,
     "lbl:longitude":3.694163,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Horebeke"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"45062",
         "eg:gisco_id":"BE_45062",
         "eurostat:nuts_2021_id":"45062"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241164,
     "wof:geomhash":"41f1bcb2143817121f7ec9a9915bcf8b",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830445,
-    "wof:lastmodified":1684351674,
+    "wof:lastmodified":1695878115,
     "wof:name":"Horebeke",
     "wof:parent_id":102049963,
     "wof:placetype":"localadmin",

--- a/data/110/883/044/9/1108830449.geojson
+++ b/data/110/883/044/9/1108830449.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.124544,
     "geom:longitude":5.073564,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.124601,
     "lbl:longitude":5.074687,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Meerhout"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13021",
         "eg:gisco_id":"BE_13021",
         "eurostat:nuts_2021_id":"13021"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241165,
     "wof:geomhash":"18deb74619f1dedc94f78b900d5e0566",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830449,
-    "wof:lastmodified":1684351674,
+    "wof:lastmodified":1695878115,
     "wof:name":"Meerhout",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/045/1/1108830451.geojson
+++ b/data/110/883/045/1/1108830451.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.113302,
     "geom:longitude":3.961414,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.112748,
     "lbl:longitude":3.955862,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Lokeren"
@@ -164,9 +176,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"46014",
         "eg:gisco_id":"BE_46014",
         "eurostat:nuts_2021_id":"46014"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241165,
     "wof:geomhash":"5c423834c804026a391b322de61f8acb",
@@ -181,7 +195,7 @@
         }
     ],
     "wof:id":1108830451,
-    "wof:lastmodified":1684351674,
+    "wof:lastmodified":1695878115,
     "wof:name":"Lokeren",
     "wof:parent_id":102049997,
     "wof:placetype":"localadmin",

--- a/data/110/883/045/3/1108830453.geojson
+++ b/data/110/883/045/3/1108830453.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.871262,
     "geom:longitude":4.486497,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.880802,
     "lbl:longitude":4.482623,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0632\u0627\u0641\u064a\u0646\u062a\u064a\u0645"
@@ -143,9 +155,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23094",
         "eg:gisco_id":"BE_23094",
         "eurostat:nuts_2021_id":"23094"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241165,
     "wof:geomhash":"5acbe6098b26c21201b2751328c290b6",
@@ -160,7 +174,7 @@
         }
     ],
     "wof:id":1108830453,
-    "wof:lastmodified":1684351674,
+    "wof:lastmodified":1695878116,
     "wof:name":"Zaventem",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/045/5/1108830455.geojson
+++ b/data/110/883/045/5/1108830455.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.320734,
     "geom:longitude":5.004365,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.320519,
     "lbl:longitude":5.000496,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Oud-Turnhout"
@@ -119,9 +131,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13031",
         "eg:gisco_id":"BE_13031",
         "eurostat:nuts_2021_id":"13031"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241165,
     "wof:geomhash":"6f247dd4adb897485ae247c62fea672c",
@@ -136,7 +150,7 @@
         }
     ],
     "wof:id":1108830455,
-    "wof:lastmodified":1684351675,
+    "wof:lastmodified":1695878116,
     "wof:name":"Oud-Turnhout",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/045/7/1108830457.geojson
+++ b/data/110/883/045/7/1108830457.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.88633,
     "geom:longitude":4.058125,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.889804,
     "lbl:longitude":4.058128,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Denderleeuw"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"41011",
         "eg:gisco_id":"BE_41011",
         "eurostat:nuts_2021_id":"41011"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241166,
     "wof:geomhash":"05a492ac19688cd37d48ae44ef36bd2f",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830457,
-    "wof:lastmodified":1684351675,
+    "wof:lastmodified":1695878116,
     "wof:name":"Denderleeuw",
     "wof:parent_id":102049967,
     "wof:placetype":"localadmin",

--- a/data/110/883/045/9/1108830459.geojson
+++ b/data/110/883/045/9/1108830459.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.761033,
     "geom:longitude":4.450847,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.763794,
     "lbl:longitude":4.447218,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bar_x_preferred":[
         "Hoeilaart"
@@ -140,9 +152,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23033",
         "eg:gisco_id":"BE_23033",
         "eurostat:nuts_2021_id":"23033"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241167,
     "wof:geomhash":"44ee25ab206549c2522c6831842f729c",
@@ -157,7 +171,7 @@
         }
     ],
     "wof:id":1108830459,
-    "wof:lastmodified":1684351675,
+    "wof:lastmodified":1695878116,
     "wof:name":"Hoeilaart",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/046/1/1108830461.geojson
+++ b/data/110/883/046/1/1108830461.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.118664,
     "geom:longitude":4.074852,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.122294,
     "lbl:longitude":4.059648,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Waasmunster"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"42023",
         "eg:gisco_id":"BE_42023",
         "eurostat:nuts_2021_id":"42023"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241167,
     "wof:geomhash":"494b8fdd9435dd534e6d16a4be262f19",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830461,
-    "wof:lastmodified":1684351675,
+    "wof:lastmodified":1695878116,
     "wof:name":"Waasmunster",
     "wof:parent_id":102049979,
     "wof:placetype":"localadmin",

--- a/data/110/883/046/3/1108830463.geojson
+++ b/data/110/883/046/3/1108830463.geojson
@@ -14,17 +14,29 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006656,
-    "geom:area_square_m":51732613.52383,
+    "geom:area_square_m":51732613.523832,
     "geom:bbox":"3.49938729961,51.011126236,3.61316948509,51.1010737506",
     "geom:latitude":51.057869,
     "geom:longitude":3.55377,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.056399,
     "lbl:longitude":3.554848,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Nevele"
@@ -113,10 +125,13 @@
         102049989
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "begov:niscode":"44049"
+    },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241168,
-    "wof:geomhash":"f546ac02a0cb0279fa2820a68fd3cda2",
+    "wof:geomhash":"3f1937d7427c9db798349bd20f82bff7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -128,7 +143,7 @@
         }
     ],
     "wof:id":1108830463,
-    "wof:lastmodified":1566611518,
+    "wof:lastmodified":1695878059,
     "wof:name":"Nevele",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/046/7/1108830467.geojson
+++ b/data/110/883/046/7/1108830467.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.117408,
     "geom:longitude":5.250468,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.118123,
     "lbl:longitude":5.251226,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Leopoldsburg"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71034",
         "eg:gisco_id":"BE_71034",
         "eurostat:nuts_2021_id":"71034"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241168,
     "wof:geomhash":"e27f6f1365c432dc6542a73d655aae77",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830467,
-    "wof:lastmodified":1684351675,
+    "wof:lastmodified":1695878117,
     "wof:name":"Leopoldsburg",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/046/9/1108830469.geojson
+++ b/data/110/883/046/9/1108830469.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.813263,
     "geom:longitude":4.163684,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.81415,
     "lbl:longitude":4.162697,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bar_x_preferred":[
         "Lennik"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23104",
         "eg:gisco_id":"BE_23104",
         "eurostat:nuts_2021_id":"23104"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241168,
     "wof:geomhash":"b3ff44b0524c090e044b0b185e9ebc07",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830469,
-    "wof:lastmodified":1684351675,
+    "wof:lastmodified":1695878117,
     "wof:name":"Lennik",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/047/1/1108830471.geojson
+++ b/data/110/883/047/1/1108830471.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.834834,
     "geom:longitude":4.842492,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.835653,
     "lbl:longitude":4.83741,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Boutersem"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24016",
         "eg:gisco_id":"BE_24016",
         "eurostat:nuts_2021_id":"24016"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241169,
     "wof:geomhash":"30907515566e4434aaf036d0392ff7e6",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830471,
-    "wof:lastmodified":1684351675,
+    "wof:lastmodified":1695878117,
     "wof:name":"Boutersem",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/047/3/1108830473.geojson
+++ b/data/110/883/047/3/1108830473.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.767975,
     "geom:longitude":4.345418,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.767613,
     "lbl:longitude":4.345412,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Linkebeek"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23100",
         "eg:gisco_id":"BE_23100",
         "eurostat:nuts_2021_id":"23100"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241169,
     "wof:geomhash":"a1485f6fccaef901f01b1610a7a40227",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830473,
-    "wof:lastmodified":1684351675,
+    "wof:lastmodified":1695878117,
     "wof:name":"Linkebeek",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/047/5/1108830475.geojson
+++ b/data/110/883/047/5/1108830475.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.830719,
     "geom:longitude":3.453904,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.832247,
     "lbl:longitude":3.453901,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Anzegem"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"34002",
         "eg:gisco_id":"BE_34002",
         "eurostat:nuts_2021_id":"34002"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241169,
     "wof:geomhash":"581115b30611f6d1b0b6ffdf994594c3",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830475,
-    "wof:lastmodified":1684351675,
+    "wof:lastmodified":1695878117,
     "wof:name":"Anzegem",
     "wof:parent_id":102049961,
     "wof:placetype":"localadmin",

--- a/data/110/883/047/7/1108830477.geojson
+++ b/data/110/883/047/7/1108830477.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.902624,
     "geom:longitude":4.44414,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.902728,
     "lbl:longitude":4.444656,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bar_x_preferred":[
         "Machelen"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23047",
         "eg:gisco_id":"BE_23047",
         "eurostat:nuts_2021_id":"23047"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241170,
     "wof:geomhash":"c8901fa53f1b1737fcd723d4975834eb",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830477,
-    "wof:lastmodified":1684351676,
+    "wof:lastmodified":1695878118,
     "wof:name":"Machelen",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/047/9/1108830479.geojson
+++ b/data/110/883/047/9/1108830479.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.992509,
     "geom:longitude":4.118962,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.989597,
     "lbl:longitude":4.118019,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Lebbeke"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"42011",
         "eg:gisco_id":"BE_42011",
         "eurostat:nuts_2021_id":"42011"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241170,
     "wof:geomhash":"4f5f915e6652bd5e3de83127b363317a",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830479,
-    "wof:lastmodified":1684351676,
+    "wof:lastmodified":1695878118,
     "wof:name":"Lebbeke",
     "wof:parent_id":102049979,
     "wof:placetype":"localadmin",

--- a/data/110/883/048/1/1108830481.geojson
+++ b/data/110/883/048/1/1108830481.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.912037,
     "geom:longitude":3.367311,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.917466,
     "lbl:longitude":3.376684,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Wielsbeke"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"37017",
         "eg:gisco_id":"BE_37017",
         "eurostat:nuts_2021_id":"37017"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241170,
     "wof:geomhash":"93aa6d64ae3c10548212c3065eff20f8",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830481,
-    "wof:lastmodified":1684351676,
+    "wof:lastmodified":1695878118,
     "wof:name":"Wielsbeke",
     "wof:parent_id":102049981,
     "wof:placetype":"localadmin",

--- a/data/110/883/048/5/1108830485.geojson
+++ b/data/110/883/048/5/1108830485.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.710659,
     "geom:longitude":3.932122,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.712394,
     "lbl:longitude":3.928671,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:cat_x_preferred":[
         "Bever"
@@ -101,9 +113,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23009",
         "eg:gisco_id":"BE_23009",
         "eurostat:nuts_2021_id":"23009"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241170,
     "wof:geomhash":"49cfa11eed3ab9c8a73740bbd3f394d7",
@@ -118,7 +132,7 @@
         }
     ],
     "wof:id":1108830485,
-    "wof:lastmodified":1684351676,
+    "wof:lastmodified":1695878118,
     "wof:name":"Bever",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/048/7/1108830487.geojson
+++ b/data/110/883/048/7/1108830487.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.355154,
     "geom:longitude":4.767497,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.351525,
     "lbl:longitude":4.763038,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Rijkevorsel"
@@ -119,9 +131,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13037",
         "eg:gisco_id":"BE_13037",
         "eurostat:nuts_2021_id":"13037"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241171,
     "wof:geomhash":"d02fd5ba0a76c31c0472ad470345b957",
@@ -136,7 +150,7 @@
         }
     ],
     "wof:id":1108830487,
-    "wof:lastmodified":1684351676,
+    "wof:lastmodified":1695878119,
     "wof:name":"Rijkevorsel",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/048/9/1108830489.geojson
+++ b/data/110/883/048/9/1108830489.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.998754,
     "geom:longitude":3.953474,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.997394,
     "lbl:longitude":3.966049,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Wichelen"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"42026",
         "eg:gisco_id":"BE_42026",
         "eurostat:nuts_2021_id":"42026"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241171,
     "wof:geomhash":"409bffc29f31a36b6c36112bea9e94ab",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830489,
-    "wof:lastmodified":1684351676,
+    "wof:lastmodified":1695878119,
     "wof:name":"Wichelen",
     "wof:parent_id":102049979,
     "wof:placetype":"localadmin",

--- a/data/110/883/049/1/1108830491.geojson
+++ b/data/110/883/049/1/1108830491.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.314403,
     "geom:longitude":4.823323,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.315214,
     "lbl:longitude":4.816932,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0628\u064a\u0631\u0633\u0647"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13004",
         "eg:gisco_id":"BE_13004",
         "eurostat:nuts_2021_id":"13004"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241171,
     "wof:geomhash":"6141b0a61aff9746270f03086e5690bb",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830491,
-    "wof:lastmodified":1684351676,
+    "wof:lastmodified":1695878119,
     "wof:name":"Beerse",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/049/3/1108830493.geojson
+++ b/data/110/883/049/3/1108830493.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.044216,
     "geom:longitude":3.80937,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.033836,
     "lbl:longitude":3.80936,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Destelbergen"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"44013",
         "eg:gisco_id":"BE_44013",
         "eurostat:nuts_2021_id":"44013"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241173,
     "wof:geomhash":"480f9ca08883641b724d2e0c8d212982",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830493,
-    "wof:lastmodified":1684351676,
+    "wof:lastmodified":1695878119,
     "wof:name":"Destelbergen",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/049/5/1108830495.geojson
+++ b/data/110/883/049/5/1108830495.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.93736,
     "geom:longitude":5.177787,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.940031,
     "lbl:longitude":5.178891,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Herk-de-Stad"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71024",
         "eg:gisco_id":"BE_71024",
         "eurostat:nuts_2021_id":"71024"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241173,
     "wof:geomhash":"da3067330d89a2ba4c2fc4dd90c631fa",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830495,
-    "wof:lastmodified":1684351676,
+    "wof:lastmodified":1695878120,
     "wof:name":"Herk-de-Stad",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/049/7/1108830497.geojson
+++ b/data/110/883/049/7/1108830497.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.882007,
     "geom:longitude":4.828937,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.882069,
     "lbl:longitude":4.827386,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Lubbeek"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24066",
         "eg:gisco_id":"BE_24066",
         "eurostat:nuts_2021_id":"24066"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241173,
     "wof:geomhash":"e2c74a2db7d6a2343b9da9d3f96d28fa",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830497,
-    "wof:lastmodified":1684351677,
+    "wof:lastmodified":1695878120,
     "wof:name":"Lubbeek",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/049/9/1108830499.geojson
+++ b/data/110/883/049/9/1108830499.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.744459,
     "geom:longitude":4.37366,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.74796,
     "lbl:longitude":4.374425,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Sint-Genesius-Rode"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23101",
         "eg:gisco_id":"BE_23101",
         "eurostat:nuts_2021_id":"23101"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241174,
     "wof:geomhash":"a52b870cd7b0f3a99a257d7eda07fc62",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830499,
-    "wof:lastmodified":1684351677,
+    "wof:lastmodified":1695878120,
     "wof:name":"Sint-Genesius-Rode",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/050/3/1108830503.geojson
+++ b/data/110/883/050/3/1108830503.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.062832,
     "geom:longitude":4.812457,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.070676,
     "lbl:longitude":4.803188,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Hulshout"
@@ -119,9 +131,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13016",
         "eg:gisco_id":"BE_13016",
         "eurostat:nuts_2021_id":"13016"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241174,
     "wof:geomhash":"7f814d82162fe6e6cbc20cc94faa6510",
@@ -136,7 +150,7 @@
         }
     ],
     "wof:id":1108830503,
-    "wof:lastmodified":1684351677,
+    "wof:lastmodified":1695878120,
     "wof:name":"Hulshout",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/050/5/1108830505.geojson
+++ b/data/110/883/050/5/1108830505.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.78094,
     "geom:longitude":4.095856,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.784125,
     "lbl:longitude":4.096977,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u062c\u0648\u064a\u0643"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23024",
         "eg:gisco_id":"BE_23024",
         "eurostat:nuts_2021_id":"23024"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241174,
     "wof:geomhash":"234012c9f54c5c5300cbc3f9e22ae7d7",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830505,
-    "wof:lastmodified":1684351677,
+    "wof:lastmodified":1695878121,
     "wof:name":"Gooik",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/050/7/1108830507.geojson
+++ b/data/110/883/050/7/1108830507.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.15625,
     "geom:longitude":4.432812,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.158897,
     "lbl:longitude":4.433448,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Edegem"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11013",
         "eg:gisco_id":"BE_11013",
         "eurostat:nuts_2021_id":"11013"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241175,
     "wof:geomhash":"599cce59eadacfbf22327d005486683a",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830507,
-    "wof:lastmodified":1684351677,
+    "wof:lastmodified":1695878121,
     "wof:name":"Edegem",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/050/9/1108830509.geojson
+++ b/data/110/883/050/9/1108830509.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.394053,
     "geom:longitude":4.600381,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.398303,
     "lbl:longitude":4.581272,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Wuustwezel"
@@ -119,9 +131,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11053",
         "eg:gisco_id":"BE_11053",
         "eurostat:nuts_2021_id":"11053"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241175,
     "wof:geomhash":"7d5d04a4749084548cc71fdb14834752",
@@ -136,7 +150,7 @@
         }
     ],
     "wof:id":1108830509,
-    "wof:lastmodified":1684351677,
+    "wof:lastmodified":1695878121,
     "wof:name":"Wuustwezel",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/051/1/1108830511.geojson
+++ b/data/110/883/051/1/1108830511.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.024783,
     "geom:longitude":3.00179,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.023579,
     "lbl:longitude":2.996983,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Kortemark"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"32011",
         "eg:gisco_id":"BE_32011",
         "eurostat:nuts_2021_id":"32011"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241175,
     "wof:geomhash":"7fdf0e0b5d84643af0fd13dc22ab747b",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830511,
-    "wof:lastmodified":1684351677,
+    "wof:lastmodified":1695878121,
     "wof:name":"Kortemark",
     "wof:parent_id":102049987,
     "wof:placetype":"localadmin",

--- a/data/110/883/051/3/1108830513.geojson
+++ b/data/110/883/051/3/1108830513.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.449493,
     "geom:longitude":4.465868,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.443743,
     "lbl:longitude":4.465881,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Essen"
@@ -350,9 +362,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11016",
         "eg:gisco_id":"BE_11016",
         "eurostat:nuts_2021_id":"11016"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241176,
     "wof:geomhash":"9f9bcd4a1cce7a5d6d20bc54df893909",
@@ -367,7 +381,7 @@
         }
     ],
     "wof:id":1108830513,
-    "wof:lastmodified":1684351677,
+    "wof:lastmodified":1695878122,
     "wof:name":"Essen",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/051/5/1108830515.geojson
+++ b/data/110/883/051/5/1108830515.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.944715,
     "geom:longitude":4.068723,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.946675,
     "lbl:longitude":4.052272,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Aalst"
@@ -98,9 +110,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"41002",
         "eg:gisco_id":"BE_41002",
         "eurostat:nuts_2021_id":"41002"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241176,
     "wof:geomhash":"b01bdb9136967cd8bc99d7bcaccf160f",
@@ -115,7 +129,7 @@
         }
     ],
     "wof:id":1108830515,
-    "wof:lastmodified":1684351678,
+    "wof:lastmodified":1695878122,
     "wof:name":"Aalst",
     "wof:parent_id":102049967,
     "wof:placetype":"localadmin",

--- a/data/110/883/051/7/1108830517.geojson
+++ b/data/110/883/051/7/1108830517.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.027767,
     "geom:longitude":3.146124,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.028781,
     "lbl:longitude":3.145479,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Lichtervelde"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"36011",
         "eg:gisco_id":"BE_36011",
         "eurostat:nuts_2021_id":"36011"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241176,
     "wof:geomhash":"1c10fd2983f9a0c798654f9c9a683bc9",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830517,
-    "wof:lastmodified":1684351678,
+    "wof:lastmodified":1695878122,
     "wof:name":"Lichtervelde",
     "wof:parent_id":102049977,
     "wof:placetype":"localadmin",

--- a/data/110/883/052/1/1108830521.geojson
+++ b/data/110/883/052/1/1108830521.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.779629,
     "geom:longitude":3.904047,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.779839,
     "lbl:longitude":3.904035,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Geraardsbergen"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"41018",
         "eg:gisco_id":"BE_41018",
         "eurostat:nuts_2021_id":"41018"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241177,
     "wof:geomhash":"516438e9e8281a4529b11e9e17469959",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830521,
-    "wof:lastmodified":1684351678,
+    "wof:lastmodified":1695878122,
     "wof:name":"Geraardsbergen",
     "wof:parent_id":102049967,
     "wof:placetype":"localadmin",

--- a/data/110/883/052/3/1108830523.geojson
+++ b/data/110/883/052/3/1108830523.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.143714,
     "geom:longitude":4.340255,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.143857,
     "lbl:longitude":4.340587,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Hemiksem"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11018",
         "eg:gisco_id":"BE_11018",
         "eurostat:nuts_2021_id":"11018"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241178,
     "wof:geomhash":"85549f5432d9c2e09a8142b351f5c901",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830523,
-    "wof:lastmodified":1684351678,
+    "wof:lastmodified":1695878123,
     "wof:name":"Hemiksem",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/052/5/1108830525.geojson
+++ b/data/110/883/052/5/1108830525.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.777606,
     "geom:longitude":3.453688,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.776291,
     "lbl:longitude":3.44157,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Avelgem"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"34003",
         "eg:gisco_id":"BE_34003",
         "eurostat:nuts_2021_id":"34003"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241178,
     "wof:geomhash":"f339d7aa26fa02ba32453a3925167415",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830525,
-    "wof:lastmodified":1684351679,
+    "wof:lastmodified":1695878123,
     "wof:name":"Avelgem",
     "wof:parent_id":102049961,
     "wof:placetype":"localadmin",

--- a/data/110/883/052/7/1108830527.geojson
+++ b/data/110/883/052/7/1108830527.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.163465,
     "geom:longitude":4.885609,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.166728,
     "lbl:longitude":4.889863,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ceb_x_preferred":[
         "Olen"
@@ -71,9 +83,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13029",
         "eg:gisco_id":"BE_13029",
         "eurostat:nuts_2021_id":"13029"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241179,
     "wof:geomhash":"89205a8bd702bf827ddd57e3aa6ea974",
@@ -88,7 +102,7 @@
         }
     ],
     "wof:id":1108830527,
-    "wof:lastmodified":1684351679,
+    "wof:lastmodified":1695878124,
     "wof:name":"Olen",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/052/9/1108830529.geojson
+++ b/data/110/883/052/9/1108830529.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.787478,
     "geom:longitude":4.24488,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.787297,
     "lbl:longitude":4.238003,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Sint-Pieters-Leeuw"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23077",
         "eg:gisco_id":"BE_23077",
         "eurostat:nuts_2021_id":"23077"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241179,
     "wof:geomhash":"26de81ada70e9395700b2c394a76f383",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830529,
-    "wof:lastmodified":1684351679,
+    "wof:lastmodified":1695878124,
     "wof:name":"Sint-Pieters-Leeuw",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/053/1/1108830531.geojson
+++ b/data/110/883/053/1/1108830531.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.16649,
     "geom:longitude":4.984769,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.171611,
     "lbl:longitude":4.975798,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Geel"
@@ -155,9 +167,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13008",
         "eg:gisco_id":"BE_13008",
         "eurostat:nuts_2021_id":"13008"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241179,
     "wof:geomhash":"0b7faf2ec30b7a8a70943b8074be5634",
@@ -172,7 +186,7 @@
         }
     ],
     "wof:id":1108830531,
-    "wof:lastmodified":1684351679,
+    "wof:lastmodified":1695878124,
     "wof:name":"Geel",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/053/3/1108830533.geojson
+++ b/data/110/883/053/3/1108830533.geojson
@@ -14,17 +14,29 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00481,
-    "geom:area_square_m":37325033.068441,
+    "geom:area_square_m":37325033.068442,
     "geom:bbox":"3.36785801955,51.1092715751,3.52518658238,51.1598964839",
     "geom:latitude":51.132676,
     "geom:longitude":3.451546,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.133701,
     "lbl:longitude":3.459407,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Knesselare"
@@ -110,10 +122,13 @@
         102049989
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "begov:niscode":"44029"
+    },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241180,
-    "wof:geomhash":"aa6f997b7b34be2b25ee1b21a181b427",
+    "wof:geomhash":"262cfce1a8284d023e99b8a334d1c227",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -125,7 +140,7 @@
         }
     ],
     "wof:id":1108830533,
-    "wof:lastmodified":1566611553,
+    "wof:lastmodified":1695878060,
     "wof:name":"Knesselare",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/053/5/1108830535.geojson
+++ b/data/110/883/053/5/1108830535.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.095278,
     "geom:longitude":4.242834,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.091256,
     "lbl:longitude":4.215694,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Bornem"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"12007",
         "eg:gisco_id":"BE_12007",
         "eurostat:nuts_2021_id":"12007"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241180,
     "wof:geomhash":"6d061c9f402377ed06761d5347e35f76",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830535,
-    "wof:lastmodified":1684351679,
+    "wof:lastmodified":1695878124,
     "wof:name":"Bornem",
     "wof:parent_id":102049985,
     "wof:placetype":"localadmin",

--- a/data/110/883/053/9/1108830539.geojson
+++ b/data/110/883/053/9/1108830539.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.007003,
     "geom:longitude":4.784619,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.009016,
     "lbl:longitude":4.785188,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Begijnendijk"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24007",
         "eg:gisco_id":"BE_24007",
         "eurostat:nuts_2021_id":"24007"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241180,
     "wof:geomhash":"fb0e76b739d4a91ae40b50f156f9e4ff",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830539,
-    "wof:lastmodified":1684351679,
+    "wof:lastmodified":1695878125,
     "wof:name":"Begijnendijk",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/054/1/1108830541.geojson
+++ b/data/110/883/054/1/1108830541.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.198177,
     "geom:longitude":3.450329,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.197858,
     "lbl:longitude":3.451724,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0645\u0627\u0644\u062f\u064a\u062e\u064a\u0645"
@@ -146,9 +158,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"43010",
         "eg:gisco_id":"BE_43010",
         "eurostat:nuts_2021_id":"43010"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241180,
     "wof:geomhash":"6c7d877fdf14f5d30907af2f077e4972",
@@ -163,7 +177,7 @@
         }
     ],
     "wof:id":1108830541,
-    "wof:lastmodified":1684351679,
+    "wof:lastmodified":1695878125,
     "wof:name":"Maldegem",
     "wof:parent_id":102049995,
     "wof:placetype":"localadmin",

--- a/data/110/883/054/3/1108830543.geojson
+++ b/data/110/883/054/3/1108830543.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.891484,
     "geom:longitude":5.131139,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.892105,
     "lbl:longitude":5.13207,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Geetbets"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24028",
         "eg:gisco_id":"BE_24028",
         "eurostat:nuts_2021_id":"24028"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241181,
     "wof:geomhash":"d41223ae7f6ddb2e0c9f5dc21a06d865",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830543,
-    "wof:lastmodified":1684351679,
+    "wof:lastmodified":1695878125,
     "wof:name":"Geetbets",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/054/5/1108830545.geojson
+++ b/data/110/883/054/5/1108830545.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.797915,
     "geom:longitude":3.757992,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.811365,
     "lbl:longitude":3.750822,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Brakel"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"45059",
         "eg:gisco_id":"BE_45059",
         "eurostat:nuts_2021_id":"45059"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241181,
     "wof:geomhash":"185ca23dfe67749a086eb5cdb702a5ad",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830545,
-    "wof:lastmodified":1684351680,
+    "wof:lastmodified":1695878126,
     "wof:name":"Brakel",
     "wof:parent_id":102049963,
     "wof:placetype":"localadmin",

--- a/data/110/883/054/7/1108830547.geojson
+++ b/data/110/883/054/7/1108830547.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.241493,
     "geom:longitude":5.122286,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.241757,
     "lbl:longitude":5.127925,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Dessel"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13006",
         "eg:gisco_id":"BE_13006",
         "eurostat:nuts_2021_id":"13006"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241182,
     "wof:geomhash":"b0dacc3483586293a59faa9db83e25cd",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830547,
-    "wof:lastmodified":1684351680,
+    "wof:lastmodified":1695878126,
     "wof:name":"Dessel",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/054/9/1108830549.geojson
+++ b/data/110/883/054/9/1108830549.geojson
@@ -14,17 +14,29 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006043,
-    "geom:area_square_m":47115718.286925,
+    "geom:area_square_m":47115718.28693,
     "geom:bbox":"3.46674600752,50.8698142673,3.58825270364,50.9530735043",
     "geom:latitude":50.907924,
     "geom:longitude":3.529407,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.916961,
     "lbl:longitude":3.530554,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Kruishoutem"
@@ -116,10 +128,13 @@
         102049963
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "begov:niscode":"45017"
+    },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241182,
-    "wof:geomhash":"318518c417e0649835f8b21426540e29",
+    "wof:geomhash":"bfbea60dc97316f0560ac1a72b607210",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -131,7 +146,7 @@
         }
     ],
     "wof:id":1108830549,
-    "wof:lastmodified":1566611548,
+    "wof:lastmodified":1695878059,
     "wof:name":"Kruishoutem",
     "wof:parent_id":102049963,
     "wof:placetype":"localadmin",

--- a/data/110/883/055/1/1108830551.geojson
+++ b/data/110/883/055/1/1108830551.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.047377,
     "geom:longitude":4.88303,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.049759,
     "lbl:longitude":4.888797,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Herselt"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13013",
         "eg:gisco_id":"BE_13013",
         "eurostat:nuts_2021_id":"13013"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241183,
     "wof:geomhash":"33f57ac480286b1afd1bcce553e895d0",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830551,
-    "wof:lastmodified":1684351680,
+    "wof:lastmodified":1695878126,
     "wof:name":"Herselt",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/055/3/1108830553.geojson
+++ b/data/110/883/055/3/1108830553.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.90959,
     "geom:longitude":4.30932,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.905533,
     "lbl:longitude":4.306325,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Wemmel"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23102",
         "eg:gisco_id":"BE_23102",
         "eurostat:nuts_2021_id":"23102"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241183,
     "wof:geomhash":"ce9168e154bfa2e44fffeda29e5bffc4",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830553,
-    "wof:lastmodified":1684351680,
+    "wof:lastmodified":1695878127,
     "wof:name":"Wemmel",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/055/7/1108830557.geojson
+++ b/data/110/883/055/7/1108830557.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.842556,
     "geom:longitude":3.366165,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.842537,
     "lbl:longitude":3.365642,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Deerlijk"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"34009",
         "eg:gisco_id":"BE_34009",
         "eurostat:nuts_2021_id":"34009"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241183,
     "wof:geomhash":"67b91cba7911654f9ce607f94cec2bd6",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830557,
-    "wof:lastmodified":1684351680,
+    "wof:lastmodified":1695878127,
     "wof:name":"Deerlijk",
     "wof:parent_id":102049961,
     "wof:placetype":"localadmin",

--- a/data/110/883/055/9/1108830559.geojson
+++ b/data/110/883/055/9/1108830559.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.164717,
     "geom:longitude":4.108523,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.163744,
     "lbl:longitude":4.14605,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Sint-Niklaas"
@@ -197,9 +209,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"46021",
         "eg:gisco_id":"BE_46021",
         "eurostat:nuts_2021_id":"46021"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241184,
     "wof:geomhash":"dc1a3fa8fd9bfcd7adb76a6f0f9b27a4",
@@ -214,7 +228,7 @@
         }
     ],
     "wof:id":1108830559,
-    "wof:lastmodified":1684351680,
+    "wof:lastmodified":1695878127,
     "wof:name":"Sint-Niklaas",
     "wof:parent_id":102049997,
     "wof:placetype":"localadmin",

--- a/data/110/883/056/1/1108830561.geojson
+++ b/data/110/883/056/1/1108830561.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.199084,
     "geom:longitude":3.80861,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.198034,
     "lbl:longitude":3.812306,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0632\u064a\u0644\u0632\u0627\u062a\u0647"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"43018",
         "eg:gisco_id":"BE_43018",
         "eurostat:nuts_2021_id":"43018"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241184,
     "wof:geomhash":"b3275fa46380c4c72904393019766e04",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830561,
-    "wof:lastmodified":1684351681,
+    "wof:lastmodified":1695878127,
     "wof:name":"Zelzate",
     "wof:parent_id":102049995,
     "wof:placetype":"localadmin",

--- a/data/110/883/056/3/1108830563.geojson
+++ b/data/110/883/056/3/1108830563.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.937351,
     "geom:longitude":3.472652,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.933232,
     "lbl:longitude":3.477326,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Zulte"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"44081",
         "eg:gisco_id":"BE_44081",
         "eurostat:nuts_2021_id":"44081"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241184,
     "wof:geomhash":"895a360e62d927be28c71796b583f340",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830563,
-    "wof:lastmodified":1684351681,
+    "wof:lastmodified":1695878128,
     "wof:name":"Zulte",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/056/5/1108830565.geojson
+++ b/data/110/883/056/5/1108830565.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.913708,
     "geom:longitude":2.741569,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.915441,
     "lbl:longitude":2.732525,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Vleteren"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"33041",
         "eg:gisco_id":"BE_33041",
         "eurostat:nuts_2021_id":"33041"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241185,
     "wof:geomhash":"44f6611f87ffebe2ac953a5a8e4c641c",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830565,
-    "wof:lastmodified":1684351681,
+    "wof:lastmodified":1695878128,
     "wof:name":"Vleteren",
     "wof:parent_id":102049971,
     "wof:placetype":"localadmin",

--- a/data/110/883/056/7/1108830567.geojson
+++ b/data/110/883/056/7/1108830567.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.147216,
     "geom:longitude":4.48229,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.15223,
     "lbl:longitude":4.473202,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:azb_x_preferred":[
         "\u0647\u0648\u0648"
@@ -119,9 +131,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11021",
         "eg:gisco_id":"BE_11021",
         "eurostat:nuts_2021_id":"11021"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241185,
     "wof:geomhash":"32cc433434393f1b5d7497b76417db10",
@@ -136,7 +150,7 @@
         }
     ],
     "wof:id":1108830567,
-    "wof:lastmodified":1684351681,
+    "wof:lastmodified":1695878128,
     "wof:name":"Hove",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/056/9/1108830569.geojson
+++ b/data/110/883/056/9/1108830569.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.253956,
     "geom:longitude":3.131406,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.249888,
     "lbl:longitude":3.132669,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Zuienkerke"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"31042",
         "eg:gisco_id":"BE_31042",
         "eurostat:nuts_2021_id":"31042"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241185,
     "wof:geomhash":"ebc3f29e9c2eaf49d5bb34828ea59830",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830569,
-    "wof:lastmodified":1684351681,
+    "wof:lastmodified":1695878128,
     "wof:name":"Zuienkerke",
     "wof:parent_id":102050003,
     "wof:placetype":"localadmin",

--- a/data/110/883/057/1/1108830571.geojson
+++ b/data/110/883/057/1/1108830571.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.03627,
     "geom:longitude":3.979274,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.042891,
     "lbl:longitude":3.961251,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Berlare"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"42003",
         "eg:gisco_id":"BE_42003",
         "eurostat:nuts_2021_id":"42003"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241185,
     "wof:geomhash":"1f3e0ff2b7c55d1300262461c140ab8b",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830571,
-    "wof:lastmodified":1684351681,
+    "wof:lastmodified":1695878129,
     "wof:name":"Berlare",
     "wof:parent_id":102049979,
     "wof:placetype":"localadmin",

--- a/data/110/883/057/5/1108830575.geojson
+++ b/data/110/883/057/5/1108830575.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.151156,
     "geom:longitude":2.943181,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.148297,
     "lbl:longitude":2.953704,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Gistel"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"35005",
         "eg:gisco_id":"BE_35005",
         "eurostat:nuts_2021_id":"35005"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241186,
     "wof:geomhash":"0880e6a01c284b7beb4f1a39bc9b0285",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830575,
-    "wof:lastmodified":1684351681,
+    "wof:lastmodified":1695878129,
     "wof:name":"Gistel",
     "wof:parent_id":102049999,
     "wof:placetype":"localadmin",

--- a/data/110/883/057/7/1108830577.geojson
+++ b/data/110/883/057/7/1108830577.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.86651,
     "geom:longitude":4.093036,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.868523,
     "lbl:longitude":4.096311,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Liedekerke"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23044",
         "eg:gisco_id":"BE_23044",
         "eurostat:nuts_2021_id":"23044"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241186,
     "wof:geomhash":"b63d4dd6345af54acdb57fb9b4a055de",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830577,
-    "wof:lastmodified":1684351681,
+    "wof:lastmodified":1695878129,
     "wof:name":"Liedekerke",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/057/9/1108830579.geojson
+++ b/data/110/883/057/9/1108830579.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.75282,
     "geom:longitude":3.988019,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.752578,
     "lbl:longitude":4.004896,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Galmaarden"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23023",
         "eg:gisco_id":"BE_23023",
         "eurostat:nuts_2021_id":"23023"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241187,
     "wof:geomhash":"e7b4a46765e51d48c1822f8776c1a04f",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830579,
-    "wof:lastmodified":1684351681,
+    "wof:lastmodified":1695878129,
     "wof:name":"Galmaarden",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/058/1/1108830581.geojson
+++ b/data/110/883/058/1/1108830581.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.771272,
     "geom:longitude":4.532876,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.769699,
     "lbl:longitude":4.538344,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Overijse"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23062",
         "eg:gisco_id":"BE_23062",
         "eurostat:nuts_2021_id":"23062"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241189,
     "wof:geomhash":"9879e79f6bcf619c11a3dedd55314e70",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830581,
-    "wof:lastmodified":1684351682,
+    "wof:lastmodified":1695878130,
     "wof:name":"Overijse",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/058/3/1108830583.geojson
+++ b/data/110/883/058/3/1108830583.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.877235,
     "geom:longitude":3.723987,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.875864,
     "lbl:longitude":3.723235,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Zwalm"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"45065",
         "eg:gisco_id":"BE_45065",
         "eurostat:nuts_2021_id":"45065"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241189,
     "wof:geomhash":"6208c7bc197c5745e7a8ca73c08f4b8d",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830583,
-    "wof:lastmodified":1684351682,
+    "wof:lastmodified":1695878130,
     "wof:name":"Zwalm",
     "wof:parent_id":102049963,
     "wof:placetype":"localadmin",

--- a/data/110/883/058/5/1108830585.geojson
+++ b/data/110/883/058/5/1108830585.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.759742,
     "geom:longitude":2.897591,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.76055,
     "lbl:longitude":2.900402,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0645\u064a\u0633\u0646"
@@ -140,9 +152,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"33016",
         "eg:gisco_id":"BE_33016",
         "eurostat:nuts_2021_id":"33016"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241190,
     "wof:geomhash":"4eb52aaa175f264f9b9a3a4ddea32a4f",
@@ -157,7 +171,7 @@
         }
     ],
     "wof:id":1108830585,
-    "wof:lastmodified":1684351682,
+    "wof:lastmodified":1695878130,
     "wof:name":"Mesen",
     "wof:parent_id":102049971,
     "wof:placetype":"localadmin",

--- a/data/110/883/058/7/1108830587.geojson
+++ b/data/110/883/058/7/1108830587.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.975708,
     "geom:longitude":2.677639,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.969165,
     "lbl:longitude":2.663975,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Alveringem"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"38002",
         "eg:gisco_id":"BE_38002",
         "eurostat:nuts_2021_id":"38002"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241190,
     "wof:geomhash":"edd0993021f8b13ac5be28e022f60e0b",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830587,
-    "wof:lastmodified":1684351682,
+    "wof:lastmodified":1695878130,
     "wof:name":"Alveringem",
     "wof:parent_id":102049991,
     "wof:placetype":"localadmin",

--- a/data/110/883/058/9/1108830589.geojson
+++ b/data/110/883/058/9/1108830589.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.978881,
     "geom:longitude":4.458215,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.977784,
     "lbl:longitude":4.446159,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Zemst"
@@ -119,9 +131,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23096",
         "eg:gisco_id":"BE_23096",
         "eurostat:nuts_2021_id":"23096"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241190,
     "wof:geomhash":"10bf381d3fb275822cc68169a3ffbcb5",
@@ -136,7 +150,7 @@
         }
     ],
     "wof:id":1108830589,
-    "wof:lastmodified":1684351682,
+    "wof:lastmodified":1695878131,
     "wof:name":"Zemst",
     "wof:parent_id":102049973,
     "wof:placetype":"localadmin",

--- a/data/110/883/059/3/1108830593.geojson
+++ b/data/110/883/059/3/1108830593.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.884675,
     "geom:longitude":3.993364,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.88773,
     "lbl:longitude":3.999603,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bar_x_preferred":[
         "Haaltert"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"41024",
         "eg:gisco_id":"BE_41024",
         "eurostat:nuts_2021_id":"41024"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241190,
     "wof:geomhash":"0d321a5f26bc2ca36c62ab59d92e86ac",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830593,
-    "wof:lastmodified":1684351682,
+    "wof:lastmodified":1695878131,
     "wof:name":"Haaltert",
     "wof:parent_id":102049967,
     "wof:placetype":"localadmin",

--- a/data/110/883/059/5/1108830595.geojson
+++ b/data/110/883/059/5/1108830595.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.854329,
     "geom:longitude":2.866491,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.859045,
     "lbl:longitude":2.8665,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "reversegeo:latitude":50.859045,
     "reversegeo:longitude":2.8665,
@@ -53,9 +65,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"33011",
         "eg:gisco_id":"BE_33011",
         "eurostat:nuts_2021_id":"33011"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241191,
     "wof:geomhash":"df032419b5fa85885be35c8e0858ae04",
@@ -70,7 +84,7 @@
         }
     ],
     "wof:id":1108830595,
-    "wof:lastmodified":1684351683,
+    "wof:lastmodified":1695878132,
     "wof:name":"Ieper",
     "wof:parent_id":102049971,
     "wof:placetype":"localadmin",

--- a/data/110/883/059/7/1108830597.geojson
+++ b/data/110/883/059/7/1108830597.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.139157,
     "geom:longitude":4.759936,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.143681,
     "lbl:longitude":4.769556,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Herenthout"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13012",
         "eg:gisco_id":"BE_13012",
         "eurostat:nuts_2021_id":"13012"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241191,
     "wof:geomhash":"d08ab84b8fc23a17eca66e7e91dcbdca",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830597,
-    "wof:lastmodified":1684351683,
+    "wof:lastmodified":1695878132,
     "wof:name":"Herenthout",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/059/9/1108830599.geojson
+++ b/data/110/883/059/9/1108830599.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.737422,
     "geom:longitude":5.169496,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.738383,
     "lbl:longitude":5.148177,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Gingelom"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71017",
         "eg:gisco_id":"BE_71017",
         "eurostat:nuts_2021_id":"71017"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241191,
     "wof:geomhash":"b4429d559b3670749ebae7c95432166e",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830599,
-    "wof:lastmodified":1684351683,
+    "wof:lastmodified":1695878132,
     "wof:name":"Gingelom",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/060/1/1108830601.geojson
+++ b/data/110/883/060/1/1108830601.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.95701,
     "geom:longitude":3.609937,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.958297,
     "lbl:longitude":3.616816,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Nasaret"
@@ -356,9 +368,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"44048",
         "eg:gisco_id":"BE_44048",
         "eurostat:nuts_2021_id":"44048"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241192,
     "wof:geomhash":"0cc8ff743cbc3715073d91c5debb45dc",
@@ -373,7 +387,7 @@
         }
     ],
     "wof:id":1108830601,
-    "wof:lastmodified":1684351683,
+    "wof:lastmodified":1695878132,
     "wof:name":"Nazareth",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/060/3/1108830603.geojson
+++ b/data/110/883/060/3/1108830603.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.182209,
     "geom:longitude":3.94507,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.185036,
     "lbl:longitude":3.945812,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0645\u0648\u0631\u0628\u064a\u0643\u0647"
@@ -125,9 +137,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"44045",
         "eg:gisco_id":"BE_44045",
         "eurostat:nuts_2021_id":"44045"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241192,
     "wof:geomhash":"6212deebbcb01e9fee18ec6ec9de77b0",
@@ -142,7 +156,7 @@
         }
     ],
     "wof:id":1108830603,
-    "wof:lastmodified":1684351683,
+    "wof:lastmodified":1695878133,
     "wof:name":"Moerbeke",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/060/5/1108830605.geojson
+++ b/data/110/883/060/5/1108830605.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.932875,
     "geom:longitude":5.575415,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.935647,
     "lbl:longitude":5.576229,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Zutendaal"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71067",
         "eg:gisco_id":"BE_71067",
         "eurostat:nuts_2021_id":"71067"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241193,
     "wof:geomhash":"2a39137faf26bf64ce78c16277927ee7",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830605,
-    "wof:lastmodified":1684351683,
+    "wof:lastmodified":1695878133,
     "wof:name":"Zutendaal",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/060/7/1108830607.geojson
+++ b/data/110/883/060/7/1108830607.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.334726,
     "geom:longitude":5.08546,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.336908,
     "lbl:longitude":5.084406,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0623\u0631\u064a\u0646\u062f\u0648\u0646\u0643"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13001",
         "eg:gisco_id":"BE_13001",
         "eurostat:nuts_2021_id":"13001"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241193,
     "wof:geomhash":"60d49c818ce29d8500574c5deadb6fc9",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830607,
-    "wof:lastmodified":1684351683,
+    "wof:lastmodified":1695878133,
     "wof:name":"Arendonk",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/061/1/1108830611.geojson
+++ b/data/110/883/061/1/1108830611.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.128432,
     "geom:longitude":5.461589,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.13725,
     "lbl:longitude":5.460408,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ceb_x_preferred":[
         "Peer"
@@ -83,9 +95,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"72030",
         "eg:gisco_id":"BE_72030",
         "eurostat:nuts_2021_id":"72030"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241193,
     "wof:geomhash":"47f8c3ed8fb1106ed508be03c4c7422b",
@@ -100,7 +114,7 @@
         }
     ],
     "wof:id":1108830611,
-    "wof:lastmodified":1684351683,
+    "wof:lastmodified":1695878133,
     "wof:name":"Peer",
     "wof:parent_id":102049993,
     "wof:placetype":"localadmin",

--- a/data/110/883/061/3/1108830613.geojson
+++ b/data/110/883/061/3/1108830613.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.06547,
     "geom:longitude":5.236061,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.065528,
     "lbl:longitude":5.225114,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:als_x_preferred":[
         "Beringen"
@@ -101,9 +113,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71004",
         "eg:gisco_id":"BE_71004",
         "eurostat:nuts_2021_id":"71004"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241194,
     "wof:geomhash":"511ebdc8e68e63265b1b03eb1ed354e9",
@@ -118,7 +132,7 @@
         }
     ],
     "wof:id":1108830613,
-    "wof:lastmodified":1684351684,
+    "wof:lastmodified":1695878134,
     "wof:name":"Beringen",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/061/5/1108830615.geojson
+++ b/data/110/883/061/5/1108830615.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.12767,
     "geom:longitude":4.497903,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.124009,
     "lbl:longitude":4.491443,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ceb_x_preferred":[
         "Lint"
@@ -74,9 +86,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11025",
         "eg:gisco_id":"BE_11025",
         "eurostat:nuts_2021_id":"11025"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:coterminous":[
         101754407
     ],
@@ -94,7 +108,7 @@
         }
     ],
     "wof:id":1108830615,
-    "wof:lastmodified":1684351684,
+    "wof:lastmodified":1695878134,
     "wof:name":"Lint",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/061/7/1108830617.geojson
+++ b/data/110/883/061/7/1108830617.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.879534,
     "geom:longitude":5.205038,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.877049,
     "lbl:longitude":5.194621,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Nieuwerkerken"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71045",
         "eg:gisco_id":"BE_71045",
         "eurostat:nuts_2021_id":"71045"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241199,
     "wof:geomhash":"db4d56ead7cc31f06fede88aa6d0cce3",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830617,
-    "wof:lastmodified":1684351684,
+    "wof:lastmodified":1695878134,
     "wof:name":"Nieuwerkerken",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/061/9/1108830619.geojson
+++ b/data/110/883/061/9/1108830619.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.309506,
     "geom:longitude":4.500424,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.312893,
     "lbl:longitude":4.500429,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Brasschaat"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11008",
         "eg:gisco_id":"BE_11008",
         "eurostat:nuts_2021_id":"11008"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241200,
     "wof:geomhash":"86c50a32a09d13cef94dc456cb018b5b",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830619,
-    "wof:lastmodified":1684351684,
+    "wof:lastmodified":1695878135,
     "wof:name":"Brasschaat",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/062/1/1108830621.geojson
+++ b/data/110/883/062/1/1108830621.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.254445,
     "geom:longitude":4.236562,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.261048,
     "lbl:longitude":4.229714,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0628\u064a\u0641\u064a\u0631\u0646"
@@ -167,9 +179,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"46003",
         "eg:gisco_id":"BE_46003",
         "eurostat:nuts_2021_id":"46003"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241200,
     "wof:geomhash":"cd11f001f72ccfe28ea0d34c72e6b3bb",
@@ -184,7 +198,7 @@
         }
     ],
     "wof:id":1108830621,
-    "wof:lastmodified":1684351684,
+    "wof:lastmodified":1695878135,
     "wof:name":"Beveren",
     "wof:parent_id":102049997,
     "wof:placetype":"localadmin",

--- a/data/110/883/062/3/1108830623.geojson
+++ b/data/110/883/062/3/1108830623.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.008643,
     "geom:longitude":5.584763,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.001621,
     "lbl:longitude":5.579197,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "reversegeo:latitude":51.001621,
     "reversegeo:longitude":5.579197,
@@ -53,9 +65,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71002",
         "eg:gisco_id":"BE_71002",
         "eurostat:nuts_2021_id":"71002"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241200,
     "wof:geomhash":"1181f7e6b29e0bdc7b1d7627b04b3000",
@@ -70,7 +84,7 @@
         }
     ],
     "wof:id":1108830623,
-    "wof:lastmodified":1684351685,
+    "wof:lastmodified":1695878135,
     "wof:name":"As",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/062/5/1108830625.geojson
+++ b/data/110/883/062/5/1108830625.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.229558,
     "geom:longitude":4.516875,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.231434,
     "lbl:longitude":4.525859,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Wijnegem"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11050",
         "eg:gisco_id":"BE_11050",
         "eurostat:nuts_2021_id":"11050"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241201,
     "wof:geomhash":"2724453fa8ccbdc862ec13532a4cae4b",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830625,
-    "wof:lastmodified":1684351685,
+    "wof:lastmodified":1695878136,
     "wof:name":"Wijnegem",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/062/9/1108830629.geojson
+++ b/data/110/883/062/9/1108830629.geojson
@@ -14,17 +14,29 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009749,
-    "geom:area_square_m":75876854.169405,
+    "geom:area_square_m":75876854.169404,
     "geom:bbox":"3.41338398337,50.9471413642,3.61106040269,51.030255212",
     "geom:latitude":50.990373,
     "geom:longitude":3.516494,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.986188,
     "lbl:longitude":3.534349,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Deinze"
@@ -122,10 +134,13 @@
         102049989
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "begov:niscode":"44011"
+    },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241201,
-    "wof:geomhash":"5ff5ffad40176a8e33d5d71699f58951",
+    "wof:geomhash":"1e7c48545659ff915cfd961e286badac",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -137,7 +152,7 @@
         }
     ],
     "wof:id":1108830629,
-    "wof:lastmodified":1566611546,
+    "wof:lastmodified":1695878059,
     "wof:name":"Deinze",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/063/1/1108830631.geojson
+++ b/data/110/883/063/1/1108830631.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.821666,
     "geom:longitude":4.524524,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.82279,
     "lbl:longitude":4.537147,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Tervuren"
@@ -149,9 +161,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24104",
         "eg:gisco_id":"BE_24104",
         "eurostat:nuts_2021_id":"24104"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241201,
     "wof:geomhash":"8d38fc39c9feb3f143aa19e227134a55",
@@ -166,7 +180,7 @@
         }
     ],
     "wof:id":1108830631,
-    "wof:lastmodified":1684351685,
+    "wof:lastmodified":1695878136,
     "wof:name":"Tervuren",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/063/3/1108830633.geojson
+++ b/data/110/883/063/3/1108830633.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.370422,
     "geom:longitude":4.870216,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.36946,
     "lbl:longitude":4.869033,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0645\u064a\u0631\u0643\u0633\u0628\u0644\u0627\u0633"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13023",
         "eg:gisco_id":"BE_13023",
         "eurostat:nuts_2021_id":"13023"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241202,
     "wof:geomhash":"9456748fa8c9f00c15a93925e84505e6",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830633,
-    "wof:lastmodified":1684351685,
+    "wof:lastmodified":1695878136,
     "wof:name":"Merksplas",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/063/5/1108830635.geojson
+++ b/data/110/883/063/5/1108830635.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.001009,
     "geom:longitude":3.265568,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.001667,
     "lbl:longitude":3.261055,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Pittem"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"37011",
         "eg:gisco_id":"BE_37011",
         "eurostat:nuts_2021_id":"37011"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241202,
     "wof:geomhash":"b369795d84372f623092cbc8405fde9c",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830635,
-    "wof:lastmodified":1684351685,
+    "wof:lastmodified":1695878136,
     "wof:name":"Pittem",
     "wof:parent_id":102049981,
     "wof:placetype":"localadmin",

--- a/data/110/883/063/7/1108830637.geojson
+++ b/data/110/883/063/7/1108830637.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.107423,
     "geom:longitude":4.33559,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.106549,
     "lbl:longitude":4.336112,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ceb_x_preferred":[
         "Niel"
@@ -80,9 +92,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11030",
         "eg:gisco_id":"BE_11030",
         "eurostat:nuts_2021_id":"11030"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241203,
     "wof:geomhash":"059513379f9505596ec756ac2be8d152",
@@ -97,7 +111,7 @@
         }
     ],
     "wof:id":1108830637,
-    "wof:lastmodified":1684351685,
+    "wof:lastmodified":1695878137,
     "wof:name":"Niel",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/063/9/1108830639.geojson
+++ b/data/110/883/063/9/1108830639.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.187003,
     "geom:longitude":5.563868,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.190333,
     "lbl:longitude":5.562489,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Bocholt"
@@ -104,9 +116,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"72003",
         "eg:gisco_id":"BE_72003",
         "eurostat:nuts_2021_id":"72003"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241203,
     "wof:geomhash":"d2d6f93646a48da5ece4d7005482558e",
@@ -121,7 +135,7 @@
         }
     ],
     "wof:id":1108830639,
-    "wof:lastmodified":1684351685,
+    "wof:lastmodified":1695878137,
     "wof:name":"Bocholt",
     "wof:parent_id":102049993,
     "wof:placetype":"localadmin",

--- a/data/110/883/064/1/1108830641.geojson
+++ b/data/110/883/064/1/1108830641.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.054775,
     "geom:longitude":5.069536,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.050015,
     "lbl:longitude":5.052562,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Tessenderlo"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71057",
         "eg:gisco_id":"BE_71057",
         "eurostat:nuts_2021_id":"71057"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241203,
     "wof:geomhash":"5e01e7b4d8d8c8b111be9d03876ea1b2",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830641,
-    "wof:lastmodified":1684351685,
+    "wof:lastmodified":1695878137,
     "wof:name":"Tessenderlo",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/064/3/1108830643.geojson
+++ b/data/110/883/064/3/1108830643.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.985831,
     "geom:longitude":3.669343,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.980759,
     "lbl:longitude":3.683221,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "De Pinte"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"44012",
         "eg:gisco_id":"BE_44012",
         "eurostat:nuts_2021_id":"44012"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241204,
     "wof:geomhash":"a020788669db84046db00932bd34db93",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830643,
-    "wof:lastmodified":1684351686,
+    "wof:lastmodified":1695878138,
     "wof:name":"De Pinte",
     "wof:parent_id":102049989,
     "wof:placetype":"localadmin",

--- a/data/110/883/064/7/1108830647.geojson
+++ b/data/110/883/064/7/1108830647.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.416161,
     "geom:longitude":4.903455,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.407649,
     "lbl:longitude":4.888427,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0628\u0627\u0631\u0644\u0647- \u0647\u064a\u0631\u062a\u0648\u062e"
@@ -167,9 +179,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13002",
         "eg:gisco_id":"BE_13002",
         "eurostat:nuts_2021_id":"13002"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241204,
     "wof:geomhash":"05118f98212dcfd5f23b1a7aa9be112c",
@@ -184,7 +198,7 @@
         }
     ],
     "wof:id":1108830647,
-    "wof:lastmodified":1684351686,
+    "wof:lastmodified":1695878138,
     "wof:name":"Baarle-Hertog",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/064/9/1108830649.geojson
+++ b/data/110/883/064/9/1108830649.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.935432,
     "geom:longitude":5.308235,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.938014,
     "lbl:longitude":5.306704,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Hasselt"
@@ -236,9 +248,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71022",
         "eg:gisco_id":"BE_71022",
         "eurostat:nuts_2021_id":"71022"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241204,
     "wof:geomhash":"6aa72dfbb6c278365ec94552d20a50b2",
@@ -253,7 +267,7 @@
         }
     ],
     "wof:id":1108830649,
-    "wof:lastmodified":1684351686,
+    "wof:lastmodified":1695878138,
     "wof:name":"Hasselt",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/065/1/1108830651.geojson
+++ b/data/110/883/065/1/1108830651.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.85384,
     "geom:longitude":4.609724,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.850981,
     "lbl:longitude":4.615279,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Bertem"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24009",
         "eg:gisco_id":"BE_24009",
         "eurostat:nuts_2021_id":"24009"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241205,
     "wof:geomhash":"cfc6a26c799d63e3b9a6d8f5c786bde8",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830651,
-    "wof:lastmodified":1684351686,
+    "wof:lastmodified":1695878139,
     "wof:name":"Bertem",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/065/3/1108830653.geojson
+++ b/data/110/883/065/3/1108830653.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.867009,
     "geom:longitude":4.94943,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.872829,
     "lbl:longitude":4.949416,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Glabbeek"
@@ -119,9 +131,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24137",
         "eg:gisco_id":"BE_24137",
         "eurostat:nuts_2021_id":"24137"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241205,
     "wof:geomhash":"51450c8e81ee77edf8aae0d83aad0574",
@@ -136,7 +150,7 @@
         }
     ],
     "wof:id":1108830653,
-    "wof:lastmodified":1684351686,
+    "wof:lastmodified":1695878139,
     "wof:name":"Glabbeek",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/065/5/1108830655.geojson
+++ b/data/110/883/065/5/1108830655.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.967176,
     "geom:longitude":5.49493,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.967226,
     "lbl:longitude":5.496533,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Genk"
@@ -191,9 +203,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"71016",
         "eg:gisco_id":"BE_71016",
         "eurostat:nuts_2021_id":"71016"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241206,
     "wof:geomhash":"4b7ad9daf3cc5364c582ca0f29a104d2",
@@ -208,7 +222,7 @@
         }
     ],
     "wof:id":1108830655,
-    "wof:lastmodified":1684351686,
+    "wof:lastmodified":1695878139,
     "wof:name":"Genk",
     "wof:parent_id":102049975,
     "wof:placetype":"localadmin",

--- a/data/110/883/065/7/1108830657.geojson
+++ b/data/110/883/065/7/1108830657.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.980086,
     "geom:longitude":4.560851,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.985509,
     "lbl:longitude":4.551715,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Boortmeerbeek"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24014",
         "eg:gisco_id":"BE_24014",
         "eurostat:nuts_2021_id":"24014"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241206,
     "wof:geomhash":"48a26a314932c9aed7be85bcd76cbdbd",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830657,
-    "wof:lastmodified":1684351687,
+    "wof:lastmodified":1695878139,
     "wof:name":"Boortmeerbeek",
     "wof:parent_id":102049969,
     "wof:placetype":"localadmin",

--- a/data/110/883/065/9/1108830659.geojson
+++ b/data/110/883/065/9/1108830659.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.122674,
     "geom:longitude":4.342852,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.123287,
     "lbl:longitude":4.346297,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Schelle"
@@ -122,9 +134,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"11038",
         "eg:gisco_id":"BE_11038",
         "eurostat:nuts_2021_id":"11038"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241206,
     "wof:geomhash":"bed67e14494a17c84ad99342d879d528",
@@ -139,7 +153,7 @@
         }
     ],
     "wof:id":1108830659,
-    "wof:lastmodified":1684351687,
+    "wof:lastmodified":1695878140,
     "wof:name":"Schelle",
     "wof:parent_id":102050005,
     "wof:placetype":"localadmin",

--- a/data/110/883/066/1/1108830661.geojson
+++ b/data/110/883/066/1/1108830661.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.845117,
     "geom:longitude":5.472424,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.844039,
     "lbl:longitude":5.47583,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Hoeselt"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"73032",
         "eg:gisco_id":"BE_73032",
         "eurostat:nuts_2021_id":"73032"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241206,
     "wof:geomhash":"9cfc208f6a5c26e834937fc8088ab62c",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830661,
-    "wof:lastmodified":1684351687,
+    "wof:lastmodified":1695878140,
     "wof:name":"Hoeselt",
     "wof:parent_id":1108782563,
     "wof:placetype":"localadmin",

--- a/data/110/883/066/5/1108830665.geojson
+++ b/data/110/883/066/5/1108830665.geojson
@@ -14,17 +14,29 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005259,
-    "geom:area_square_m":40743813.731706,
+    "geom:area_square_m":40743813.731709,
     "geom:bbox":"5.32014086842,51.1642614189,5.44298046738,51.2468849786",
     "geom:latitude":51.200297,
     "geom:longitude":5.393401,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.203959,
     "lbl:longitude":5.394335,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Overpelt"
@@ -119,10 +131,13 @@
         102049993
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "begov:niscode":"72029"
+    },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241207,
-    "wof:geomhash":"e170c11052e5d6bbecea10dfcaf2b18e",
+    "wof:geomhash":"d49df18c82d389c729eed89e807c9c56",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -134,7 +149,7 @@
         }
     ],
     "wof:id":1108830665,
-    "wof:lastmodified":1566611653,
+    "wof:lastmodified":1695878061,
     "wof:name":"Overpelt",
     "wof:parent_id":102049993,
     "wof:placetype":"localadmin",

--- a/data/110/883/066/7/1108830667.geojson
+++ b/data/110/883/066/7/1108830667.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.880815,
     "geom:longitude":3.078959,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.889685,
     "lbl:longitude":3.074462,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Moorslede"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"36012",
         "eg:gisco_id":"BE_36012",
         "eurostat:nuts_2021_id":"36012"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241207,
     "wof:geomhash":"b44fc31752b6f1583230d6aa14246672",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830667,
-    "wof:lastmodified":1684351687,
+    "wof:lastmodified":1695878140,
     "wof:name":"Moorslede",
     "wof:parent_id":102049977,
     "wof:placetype":"localadmin",

--- a/data/110/883/066/9/1108830669.geojson
+++ b/data/110/883/066/9/1108830669.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.805476,
     "geom:longitude":3.836445,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.802503,
     "lbl:longitude":3.841283,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Lierde"
@@ -128,9 +140,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"45063",
         "eg:gisco_id":"BE_45063",
         "eurostat:nuts_2021_id":"45063"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241208,
     "wof:geomhash":"4bef88bde2778eb91dc9f94da8d84b26",
@@ -145,7 +159,7 @@
         }
     ],
     "wof:id":1108830669,
-    "wof:lastmodified":1684351687,
+    "wof:lastmodified":1695878140,
     "wof:name":"Lierde",
     "wof:parent_id":102049963,
     "wof:placetype":"localadmin",

--- a/data/110/883/067/1/1108830671.geojson
+++ b/data/110/883/067/1/1108830671.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":50.775393,
     "geom:longitude":2.830263,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":50.768096,
     "lbl:longitude":2.818059,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Heuvelland"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"33039",
         "eg:gisco_id":"BE_33039",
         "eurostat:nuts_2021_id":"33039"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241208,
     "wof:geomhash":"f525b34d83cec37d8fa0153292384611",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830671,
-    "wof:lastmodified":1684351687,
+    "wof:lastmodified":1695878141,
     "wof:name":"Heuvelland",
     "wof:parent_id":102049971,
     "wof:placetype":"localadmin",

--- a/data/110/883/067/3/1108830673.geojson
+++ b/data/110/883/067/3/1108830673.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.111754,
     "geom:longitude":2.679367,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.115607,
     "lbl:longitude":2.677887,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Koksijde"
@@ -137,9 +149,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"38014",
         "eg:gisco_id":"BE_38014",
         "eurostat:nuts_2021_id":"38014"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241208,
     "wof:geomhash":"7089aad63675ddb556359c2fb0ee1cc1",
@@ -154,7 +168,7 @@
         }
     ],
     "wof:id":1108830673,
-    "wof:lastmodified":1684351687,
+    "wof:lastmodified":1695878141,
     "wof:name":"Koksijde",
     "wof:parent_id":102049991,
     "wof:placetype":"localadmin",

--- a/data/110/883/067/5/1108830675.geojson
+++ b/data/110/883/067/5/1108830675.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.332466,
     "geom:longitude":3.308092,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.331353,
     "lbl:longitude":3.309615,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "Knokke-Heist"
@@ -170,9 +182,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"31043",
         "eg:gisco_id":"BE_31043",
         "eurostat:nuts_2021_id":"31043"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241209,
     "wof:geomhash":"958c359cb5a25063c547ff55b3fefb18",
@@ -187,7 +201,7 @@
         }
     ],
     "wof:id":1108830675,
-    "wof:lastmodified":1684351688,
+    "wof:lastmodified":1695878141,
     "wof:name":"Knokke-Heist",
     "wof:parent_id":102050003,
     "wof:placetype":"localadmin",

--- a/data/110/883/067/7/1108830677.geojson
+++ b/data/110/883/067/7/1108830677.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.243252,
     "geom:longitude":4.942034,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.238072,
     "lbl:longitude":4.940422,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Kasterlee"
@@ -119,9 +131,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13017",
         "eg:gisco_id":"BE_13017",
         "eurostat:nuts_2021_id":"13017"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241209,
     "wof:geomhash":"7a6c0e07b4e3f7776084390b9afa375b",
@@ -136,7 +150,7 @@
         }
     ],
     "wof:id":1108830677,
-    "wof:lastmodified":1684351688,
+    "wof:lastmodified":1695878141,
     "wof:name":"Kasterlee",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/067/9/1108830679.geojson
+++ b/data/110/883/067/9/1108830679.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.124904,
     "geom:longitude":2.764985,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.117164,
     "lbl:longitude":2.780603,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Nieuwpoort"
@@ -71,9 +83,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"38016",
         "eg:gisco_id":"BE_38016",
         "eurostat:nuts_2021_id":"38016"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241209,
     "wof:geomhash":"f2eff0b3f9c75c81bef934bf7a74bb23",
@@ -88,7 +102,7 @@
         }
     ],
     "wof:id":1108830679,
-    "wof:lastmodified":1684351688,
+    "wof:lastmodified":1695878142,
     "wof:name":"Nieuwpoort",
     "wof:parent_id":102049991,
     "wof:placetype":"localadmin",

--- a/data/110/883/068/3/1108830683.geojson
+++ b/data/110/883/068/3/1108830683.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.238092,
     "geom:longitude":2.976297,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.238983,
     "lbl:longitude":2.976843,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:als_x_preferred":[
         "Bredene"
@@ -131,9 +143,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"35002",
         "eg:gisco_id":"BE_35002",
         "eurostat:nuts_2021_id":"35002"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241210,
     "wof:geomhash":"91d667ecda4d02f785cc9f6c0937ab2f",
@@ -148,7 +162,7 @@
         }
     ],
     "wof:id":1108830683,
-    "wof:lastmodified":1684351688,
+    "wof:lastmodified":1695878142,
     "wof:name":"Bredene",
     "wof:parent_id":102049999,
     "wof:placetype":"localadmin",

--- a/data/110/883/068/5/1108830685.geojson
+++ b/data/110/883/068/5/1108830685.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.261566,
     "geom:longitude":3.047403,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.258149,
     "lbl:longitude":3.046425,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "De Haan"
@@ -65,9 +77,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"35029",
         "eg:gisco_id":"BE_35029",
         "eurostat:nuts_2021_id":"35029"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241210,
     "wof:geomhash":"bff34efb8febe25151e329c507236932",
@@ -82,7 +96,7 @@
         }
     ],
     "wof:id":1108830685,
-    "wof:lastmodified":1684351688,
+    "wof:lastmodified":1695878142,
     "wof:name":"De Haan",
     "wof:parent_id":102049999,
     "wof:placetype":"localadmin",

--- a/data/110/883/068/7/1108830687.geojson
+++ b/data/110/883/068/7/1108830687.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.210687,
     "geom:longitude":2.923651,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.218393,
     "lbl:longitude":2.922394,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "reversegeo:latitude":51.218393,
     "reversegeo:longitude":2.922394,
@@ -53,9 +65,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"35013",
         "eg:gisco_id":"BE_35013",
         "eurostat:nuts_2021_id":"35013"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241210,
     "wof:geomhash":"70d25ba5818905d526c4e5610d157371",
@@ -70,7 +84,7 @@
         }
     ],
     "wof:id":1108830687,
-    "wof:lastmodified":1684351688,
+    "wof:lastmodified":1695878142,
     "wof:name":"Oostende",
     "wof:parent_id":102049999,
     "wof:placetype":"localadmin",

--- a/data/110/883/068/9/1108830689.geojson
+++ b/data/110/883/068/9/1108830689.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.248813,
     "geom:longitude":3.21444,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.216028,
     "lbl:longitude":3.215778,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "reversegeo:latitude":51.216028,
     "reversegeo:longitude":3.215778,
@@ -53,9 +65,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"31005",
         "eg:gisco_id":"BE_31005",
         "eurostat:nuts_2021_id":"31005"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241210,
     "wof:geomhash":"35f4d9104f4d16e374cff26ee5bcae56",
@@ -70,7 +84,7 @@
         }
     ],
     "wof:id":1108830689,
-    "wof:lastmodified":1684351688,
+    "wof:lastmodified":1695878143,
     "wof:name":"Brugge",
     "wof:parent_id":102050003,
     "wof:placetype":"localadmin",

--- a/data/110/883/069/1/1108830691.geojson
+++ b/data/110/883/069/1/1108830691.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.328954,
     "geom:longitude":4.94017,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.327709,
     "lbl:longitude":4.93691,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u062a\u0648\u0631\u0646\u0647\u0627\u0648\u062a"
@@ -176,9 +188,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"13040",
         "eg:gisco_id":"BE_13040",
         "eurostat:nuts_2021_id":"13040"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241211,
     "wof:geomhash":"4554bc92f576e44bb48fa43b9fd164d2",
@@ -193,7 +207,7 @@
         }
     ],
     "wof:id":1108830691,
-    "wof:lastmodified":1684351688,
+    "wof:lastmodified":1695878143,
     "wof:name":"Turnhout",
     "wof:parent_id":102050007,
     "wof:placetype":"localadmin",

--- a/data/110/883/069/3/1108830693.geojson
+++ b/data/110/883/069/3/1108830693.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.301541,
     "geom:longitude":3.139814,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.302786,
     "lbl:longitude":3.140501,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Blankenberge"
@@ -149,9 +161,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"31004",
         "eg:gisco_id":"BE_31004",
         "eurostat:nuts_2021_id":"31004"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241211,
     "wof:geomhash":"a5609c639873369be1974d4cfd9ea7c3",
@@ -166,7 +180,7 @@
         }
     ],
     "wof:id":1108830693,
-    "wof:lastmodified":1684351688,
+    "wof:lastmodified":1695878143,
     "wof:name":"Blankenberge",
     "wof:parent_id":102050003,
     "wof:placetype":"localadmin",

--- a/data/110/883/069/5/1108830695.geojson
+++ b/data/110/883/069/5/1108830695.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.153357,
     "geom:longitude":2.838711,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.156556,
     "lbl:longitude":2.837379,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bre_x_preferred":[
         "Middelkerke"
@@ -134,9 +146,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"35011",
         "eg:gisco_id":"BE_35011",
         "eurostat:nuts_2021_id":"35011"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241211,
     "wof:geomhash":"25d23f2ffd4ef73dffb54e86fbee927c",
@@ -151,7 +165,7 @@
         }
     ],
     "wof:id":1108830695,
-    "wof:lastmodified":1684351689,
+    "wof:lastmodified":1695878143,
     "wof:name":"Middelkerke",
     "wof:parent_id":102049999,
     "wof:placetype":"localadmin",

--- a/data/110/883/069/7/1108830697.geojson
+++ b/data/110/883/069/7/1108830697.geojson
@@ -31,12 +31,24 @@
     "geom:latitude":51.080707,
     "geom:longitude":2.588274,
     "iso:country":"BE",
+    "label:deu_x_preferred_placetype":[
+        "gemeinde"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeinde"
+    ],
     "lbl:latitude":51.081959,
     "lbl:longitude":2.588271,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:afr_x_preferred":[
         "De Panne"
@@ -146,9 +158,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"38008",
         "eg:gisco_id":"BE_38008",
         "eurostat:nuts_2021_id":"38008"
     },
+    "wof:concordances_official":"begov:niscode",
     "wof:country":"BE",
     "wof:created":1488241212,
     "wof:geomhash":"aae1bbaa273e8be7a000c75d75eaf0b1",
@@ -163,7 +177,7 @@
         }
     ],
     "wof:id":1108830697,
-    "wof:lastmodified":1684351689,
+    "wof:lastmodified":1695878144,
     "wof:name":"De Panne",
     "wof:parent_id":102049991,
     "wof:placetype":"localadmin",

--- a/data/404/227/353/404227353.geojson
+++ b/data/404/227/353/404227353.geojson
@@ -417,10 +417,12 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eurostat:nuts_2021_id":"BE3",
+        "iso:code":"BE-WAL",
         "wd:id":"Q231"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BE",
-    "wof:geomhash":"f6b0225c7f52cf3883c58e4b5b43a980",
+    "wof:geomhash":"05efcff6da2d970d87e448d4686a0dec",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -439,7 +441,7 @@
         "fra",
         "deu"
     ],
-    "wof:lastmodified":1690856673,
+    "wof:lastmodified":1695884169,
     "wof:name":"Wallonia",
     "wof:parent_id":85632997,
     "wof:placetype":"macroregion",

--- a/data/404/227/357/404227357.geojson
+++ b/data/404/227/357/404227357.geojson
@@ -274,10 +274,12 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eurostat:nuts_2021_id":"BE2",
+        "iso:code":"BE-VLG",
         "wd:id":"Q9337"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BE",
-    "wof:geomhash":"dbdc438dbedfc7db0ecbf46b0ba0757e",
+    "wof:geomhash":"c807ab4942c008e3ee07dd82aaa3f0db",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -296,7 +298,7 @@
         "fra",
         "deu"
     ],
-    "wof:lastmodified":1690856674,
+    "wof:lastmodified":1695884169,
     "wof:name":"Flemish Region",
     "wof:parent_id":85632997,
     "wof:placetype":"macroregion",

--- a/data/856/329/97/85632997.geojson
+++ b/data/856/329/97/85632997.geojson
@@ -1395,6 +1395,7 @@
         "hasc:id":"BE",
         "icao:code":"OO",
         "ioc:id":"BEL",
+        "iso:code":"BE",
         "itu:id":"BEL",
         "loc:id":"n80126041",
         "m49:code":"056",
@@ -1409,6 +1410,7 @@
         "wk:page":"Belgium",
         "wmo:id":"BX"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BE",
     "wof:country_alpha3":"BEL",
     "wof:geom_alt":[
@@ -1433,7 +1435,7 @@
         "fra",
         "deu"
     ],
-    "wof:lastmodified":1694492228,
+    "wof:lastmodified":1695881341,
     "wof:name":"Belgium",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/816/91/85681691.geojson
+++ b/data/856/816/91/85681691.geojson
@@ -183,15 +183,21 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"36",
         "digitalenvoy:region_code":11056,
         "eurostat:nuts_2021_id":"BE33",
         "fips:code":"BE04",
         "gn:id":2792411,
         "gp:id":7153300,
         "hasc:id":"BE.LG",
+        "iso:code":"BE-WLG",
         "iso:id":"BE-WLG",
         "unlc:id":"BE-WLG"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"bdbebcc332fb8e4d1c5a423262fe73bd",
     "wof:hierarchy":[
@@ -213,7 +219,7 @@
         "fra",
         "deu"
     ],
-    "wof:lastmodified":1684351396,
+    "wof:lastmodified":1695885160,
     "wof:name":"Liege",
     "wof:parent_id":404227353,
     "wof:placetype":"region",

--- a/data/856/816/93/85681693.geojson
+++ b/data/856/816/93/85681693.geojson
@@ -190,15 +190,21 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"32",
         "digitalenvoy:region_code":11081,
         "eurostat:nuts_2021_id":"BE31",
         "fips:code":"BE10",
         "gn:id":3333251,
         "gp:id":22525997,
         "hasc:id":"BE.BW",
+        "iso:code":"BE-WBR",
         "iso:id":"BE-WBR",
         "unlc:id":"BE-WBR"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"102f902d3e450b0409f6f7c2b621b628",
     "wof:hierarchy":[
@@ -220,7 +226,7 @@
         "fra",
         "deu"
     ],
-    "wof:lastmodified":1684351396,
+    "wof:lastmodified":1695885160,
     "wof:name":"Brabant wallon",
     "wof:parent_id":404227353,
     "wof:placetype":"region",

--- a/data/856/816/99/85681699.geojson
+++ b/data/856/816/99/85681699.geojson
@@ -390,15 +390,21 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"39",
         "digitalenvoy:region_code":11073,
         "eurostat:nuts_2021_id":"BE35",
         "fips:code":"BE07",
         "gn:id":2790469,
         "gp:id":7153303,
         "hasc:id":"BE.NA",
+        "iso:code":"BE-WNA",
         "iso:id":"BE-WNA",
         "unlc:id":"BE-WNA"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"d28bae6709386ddeeda3ce03453fbfaa",
     "wof:hierarchy":[
@@ -420,7 +426,7 @@
         "fra",
         "deu"
     ],
-    "wof:lastmodified":1684351396,
+    "wof:lastmodified":1695885160,
     "wof:name":"Namur",
     "wof:parent_id":404227353,
     "wof:placetype":"region",

--- a/data/856/817/05/85681705.geojson
+++ b/data/856/817/05/85681705.geojson
@@ -322,15 +322,21 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"27",
         "digitalenvoy:region_code":11071,
         "eurostat:nuts_2021_id":"BE22",
         "fips:code":"BE05",
         "gn:id":2792347,
         "gp:id":7153301,
         "hasc:id":"BE.LI",
+        "iso:code":"BE-VLI",
         "iso:id":"BE-VLI",
         "unlc:id":"BE-VLI"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"c6c203fbf8e8edd5718915f4246e55df",
     "wof:hierarchy":[
@@ -352,7 +358,7 @@
         "fra",
         "deu"
     ],
-    "wof:lastmodified":1684351396,
+    "wof:lastmodified":1695885160,
     "wof:name":"Limburg",
     "wof:parent_id":404227357,
     "wof:placetype":"region",

--- a/data/856/817/09/85681709.geojson
+++ b/data/856/817/09/85681709.geojson
@@ -191,14 +191,20 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"23",
         "digitalenvoy:region_code":11058,
         "eurostat:nuts_2021_id":"BE25",
         "fips:code":"BE09",
         "gn:id":2783770,
         "gp:id":7153305,
         "hasc:id":"BE.WV",
+        "iso:code":"BE-VWV",
         "iso:id":"BE-VWV"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"b599549a842cf4203ff10c1204501df0",
     "wof:hierarchy":[
@@ -220,7 +226,7 @@
         "fra",
         "deu"
     ],
-    "wof:lastmodified":1684351396,
+    "wof:lastmodified":1695885160,
     "wof:name":"West-Vlaanderen",
     "wof:parent_id":404227357,
     "wof:placetype":"region",

--- a/data/856/817/13/85681713.geojson
+++ b/data/856/817/13/85681713.geojson
@@ -659,21 +659,27 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"40",
         "digitalenvoy:region_code":28295,
         "eurostat:nuts_2021_id":"BE10",
         "fips:code":"BE11",
         "gn:id":6693370,
         "gp:id":55965974,
         "hasc:id":"BE.BR",
+        "iso:code":"BE-BRU",
         "iso:id":"BE-BRU",
         "unlc:id":"BE-BRU",
         "wd:id":"Q240"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         1175610569
     ],
     "wof:country":"BE",
-    "wof:geomhash":"63ba5553be5939d695f2c2c22f43ea7a",
+    "wof:geomhash":"52f9d4327c9f4727b8607f6b10906bc8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -693,7 +699,7 @@
         "fra",
         "deu"
     ],
-    "wof:lastmodified":1690856405,
+    "wof:lastmodified":1695885160,
     "wof:name":"Brussels-Capital Region",
     "wof:parent_id":404227355,
     "wof:placetype":"region",

--- a/data/856/817/15/85681715.geojson
+++ b/data/856/817/15/85681715.geojson
@@ -580,18 +580,24 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"21",
         "digitalenvoy:region_code":11057,
         "eurostat:nuts_2021_id":"BE21",
         "fips:code":"BE01",
         "gn:id":2803136,
         "gp:id":7153308,
         "hasc:id":"BE.AN",
+        "iso:code":"BE-VAN",
         "iso:id":"BE-VAN",
         "unlc:id":"BE-VAN",
         "wd:id":"Q12892"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"4571ce636ce417dcd9886f1b0a3578f1",
+    "wof:geomhash":"2d2e02b4e2d0e704fbf048cb77a11dcc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -611,7 +617,7 @@
         "fra",
         "deu"
     ],
-    "wof:lastmodified":1690856405,
+    "wof:lastmodified":1695885160,
     "wof:name":"Antwerpen",
     "wof:parent_id":404227357,
     "wof:placetype":"region",

--- a/data/856/817/23/85681723.geojson
+++ b/data/856/817/23/85681723.geojson
@@ -207,15 +207,21 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"35",
         "digitalenvoy:region_code":11062,
         "eurostat:nuts_2021_id":"BE32",
         "fips:code":"BE03",
         "gn:id":2796741,
         "gp:id":7153299,
         "hasc:id":"BE.HT",
+        "iso:code":"BE-WHT",
         "iso:id":"BE-WHT",
         "unlc:id":"BE-WHT"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"f5724bd0f7b6ee0007196e0ab36722df",
     "wof:hierarchy":[
@@ -237,7 +243,7 @@
         "fra",
         "deu"
     ],
-    "wof:lastmodified":1684351396,
+    "wof:lastmodified":1695885160,
     "wof:name":"Hainaut",
     "wof:parent_id":404227353,
     "wof:placetype":"region",

--- a/data/856/817/27/85681727.geojson
+++ b/data/856/817/27/85681727.geojson
@@ -845,15 +845,21 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"38",
         "digitalenvoy:region_code":11060,
         "eurostat:nuts_2021_id":"BE34",
         "fips:code":"BE06",
         "gn:id":2791993,
         "gp:id":7153302,
         "hasc:id":"BE.LX",
+        "iso:code":"BE-WLX",
         "iso:id":"BE-WLX",
         "unlc:id":"BE-WLX"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"75f1a8a68325855159967104afeadbdc",
     "wof:hierarchy":[
@@ -875,7 +881,7 @@
         "fra",
         "deu"
     ],
-    "wof:lastmodified":1684351396,
+    "wof:lastmodified":1695885160,
     "wof:name":"Luxembourg",
     "wof:parent_id":404227353,
     "wof:placetype":"region",

--- a/data/856/817/31/85681731.geojson
+++ b/data/856/817/31/85681731.geojson
@@ -460,18 +460,24 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"22",
         "digitalenvoy:region_code":14480,
         "eurostat:nuts_2021_id":"BE24",
         "fips:code":"BE12",
         "gn:id":3333250,
         "gp:id":22525998,
         "hasc:id":"BE.VB",
+        "iso:code":"BE-VBR",
         "iso:id":"BE-VBR",
         "unlc:id":"BE-VBR",
         "wd:id":"Q1118"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BE",
-    "wof:geomhash":"6fdfc5afd3afa1ac14b1254aa723f6c8",
+    "wof:geomhash":"8f88ee00c273659f9349d46f1c7f0b26",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -491,7 +497,7 @@
         "fra",
         "deu"
     ],
-    "wof:lastmodified":1690856404,
+    "wof:lastmodified":1695885161,
     "wof:name":"Vlaams-Brabant",
     "wof:parent_id":404227357,
     "wof:placetype":"region",

--- a/data/856/817/33/85681733.geojson
+++ b/data/856/817/33/85681733.geojson
@@ -198,14 +198,20 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "begov:niscode":"24",
         "digitalenvoy:region_code":11054,
         "eurostat:nuts_2021_id":"BE23",
         "fips:code":"BE08",
         "gn:id":2789733,
         "gp:id":7153304,
         "hasc:id":"BE.OV",
+        "iso:code":"BE-VOV",
         "iso:id":"BE-VOV"
     },
+    "wof:concordances_official":"begov:niscode",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"BE",
     "wof:geomhash":"6e60305630899c6ea330ff0be74ee576",
     "wof:hierarchy":[
@@ -227,7 +233,7 @@
         "fra",
         "deu"
     ],
-    "wof:lastmodified":1684351396,
+    "wof:lastmodified":1695885161,
     "wof:name":"Oost-Vlaanderen",
     "wof:parent_id":404227357,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.